### PR TITLE
[P2-ops] CI gate + one-click local run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - claw/**
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: backend (check + test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Static check
+        run: npm run check
+
+      - name: Unit tests
+        run: npm test
+
+  frontend:
+    name: frontend (build)
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('web/package.json') != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+
+      - name: Build
+        working-directory: web
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@ This repo contains the **backend aggregation API** (Node http server) and a **Da
 Prereqs: Node.js >= 20.
 
 ```bash
+# from repo root
 npm install
 npm run check
 npm test
+
+export OPENCLAW_RUNTIME_DIR=/abs/path/to/claw_team/runtime
 npm start
+# -> http://127.0.0.1:3000
 ```
 
 API base (preferred): `http://127.0.0.1:3000/api/...`
@@ -59,6 +63,18 @@ When enabled by config:
 - Backup is written to: `.rollback/markdown-edits/`
 - Audit record is appended to: `.audit/markdown-edits.jsonl`
 
+## One-click local run
+
+```bash
+export OPENCLAW_RUNTIME_DIR=/abs/path/to/claw_team/runtime
+./scripts/run_local.sh
+```
+
+Notes:
+
+- `OPENCLAW_RUNTIME_DIR` should point at a directory containing `scores.json`, `tasks.json`, and `events.json` (for example `claw_team/runtime`).
+- If a `web/` frontend exists, `./scripts/run_local.sh` will attempt to start it as well (best-effort). Otherwise it only starts the backend.
+
 ## Frontend (Dashboard + Agent detail + Markdown)
 
 ```bash
@@ -74,3 +90,11 @@ Routes (frontend):
 - `/agents/:agentId` agent detail
 - `/markdown` markdown allowlist list
 - `/markdown/:fileId` markdown editor (preview diff + save)
+
+## CI
+
+GitHub Actions runs:
+
+- backend: `npm run check` + `npm test`
+- markdown boundaries validation (`scripts/check_markdown_boundaries.py`)
+- frontend build only when `web/package.json` exists

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Default to a sibling claw_team/runtime if present (convenience for local dev).
+DEFAULT_RUNTIME_DIR=""
+if [ -d "${ROOT_DIR}/../claw_team/runtime" ]; then
+  DEFAULT_RUNTIME_DIR="$(cd "${ROOT_DIR}/../claw_team/runtime" && pwd)"
+fi
+
+OPENCLAW_RUNTIME_DIR="${OPENCLAW_RUNTIME_DIR:-$DEFAULT_RUNTIME_DIR}"
+PORT="${PORT:-3000}"
+
+if [ -z "${OPENCLAW_RUNTIME_DIR}" ] || [ ! -d "${OPENCLAW_RUNTIME_DIR}" ]; then
+  cat <<EOF
+[openclaw-monitor] OPENCLAW_RUNTIME_DIR not set or not found.
+
+Example:
+  export OPENCLAW_RUNTIME_DIR=/abs/path/to/claw_team/runtime
+  ./scripts/run_local.sh
+EOF
+  exit 2
+fi
+
+cd "${ROOT_DIR}"
+
+echo "[openclaw-monitor] Using OPENCLAW_RUNTIME_DIR=${OPENCLAW_RUNTIME_DIR}"
+echo "[openclaw-monitor] Backend: http://127.0.0.1:${PORT}"
+
+export OPENCLAW_RUNTIME_DIR
+export PORT
+
+# Start backend.
+node src/server.js &
+BACKEND_PID=$!
+
+cleanup() {
+  if kill -0 "$BACKEND_PID" 2>/dev/null; then
+    kill "$BACKEND_PID" || true
+  fi
+}
+trap cleanup EXIT
+
+# Optional: start frontend if it exists and has a build/dev script.
+if [ -f web/package.json ]; then
+  echo "[openclaw-monitor] Detected web/ frontend. Starting it (best-effort)…"
+  ( 
+    cd web
+    if [ -f package-lock.json ]; then npm ci; else npm install; fi
+    # Prefer dev, else start.
+    if node -e "const p=require('./package.json');process.exit(p.scripts&&p.scripts.dev?0:1)"; then
+      npm run dev
+    else
+      npm start
+    fi
+  )
+else
+  echo "[openclaw-monitor] No web/ directory found. Backend running; Ctrl+C to stop."
+  wait "$BACKEND_PID"
+fi


### PR DESCRIPTION
Closes #40\n\n- Add GitHub Actions workflow to run backend checks + unit tests on PRs/pushes\n- Keep markdown-boundaries workflow as separate required check\n- Add README + scripts/run_local.sh (uses OPENCLAW_RUNTIME_DIR; optionally starts web/ if present)