### PR TITLE
feat(ui): Agent详情页 + Markdown受控编辑 (V1)

### DIFF
--- a/src/public/agent.js
+++ b/src/public/agent.js
@@ -1,0 +1,102 @@
+(function initAgentDetail() {
+  const { byId, setText, setHtml, fmtTime, fetchJson, esc } = window.oc;
+
+  const agentId = document.body.dataset.agentId;
+
+  const statusEl = byId('status');
+  const kvsEl = byId('kvs');
+  const eventsEl = byId('events');
+  const sourcesEl = byId('sources');
+  const mdEl = byId('md');
+
+  function kvRow(label, value) {
+    return `<div class="muted">${esc(label)}</div><div>${value ?? '—'}</div>`;
+  }
+
+  function eventItem(evt) {
+    const sev = String(evt.severity || 'info').toLowerCase();
+    const cls = sev === 'error' ? 'err' : sev === 'warning' ? 'warn' : 'ok';
+    return `
+      <div class="item">
+        <div class="top">
+          <div><span class="dot ${cls}"></span> <b>${esc(evt.title || evt.kind || 'event')}</b></div>
+          <div class="muted">${esc(fmtTime(evt.timestamp || evt.occurredAt))}</div>
+        </div>
+        <div class="meta">${esc(evt.summary || '')}</div>
+      </div>
+    `;
+  }
+
+  function sourceItem(src) {
+    const s = String(src.status || 'unknown').toLowerCase();
+    const cls = s === 'ok' ? 'ok' : s === 'degraded' ? 'warn' : 'err';
+    return `
+      <div class="item">
+        <div class="top"><div><span class="dot ${cls}"></span> <b>${esc(src.name)}</b></div><div class="muted">${esc(fmtTime(src.collectedAt))}</div></div>
+        <div class="meta">${esc(src.message || '')}</div>
+      </div>
+    `;
+  }
+
+  function mdItem(file) {
+    const link = '/markdown/' + encodeURIComponent(file.fileId);
+    return `
+      <div class="item">
+        <div class="top"><div><a href="${link}">${esc(file.name)}</a></div><div class="muted">${file.writable ? 'writable' : 'read-only'}</div></div>
+        <div class="meta">${esc(file.path)} · updated ${esc(fmtTime(file.updatedAt))}</div>
+      </div>
+    `;
+  }
+
+  (async () => {
+    const detail = await fetchJson('/api/v1/agents/' + encodeURIComponent(agentId));
+    if (!detail.ok) {
+      statusEl.className = 'status err';
+      setText(statusEl, `加载失败：${detail.payload?.error?.message || detail.status}`);
+      return;
+    }
+
+    const data = detail.payload.data;
+    statusEl.className = 'status ok';
+    setText(
+      statusEl,
+      `OK · ${data.displayName || data.agentId} · status=${data.status || 'unknown'} · collectedAt=${fmtTime(detail.payload.meta?.collectedAt)}`,
+    );
+
+    const issueUrl = data.activeTask?.issueUrl;
+    const issueHtml = issueUrl
+      ? `<a href="${esc(issueUrl)}" target="_blank" rel="noreferrer">${esc(issueUrl)}</a>`
+      : '—';
+
+    setHtml(
+      kvsEl,
+      [
+        kvRow('agentId', esc(data.agentId)),
+        kvRow('displayName', esc(data.displayName)),
+        kvRow('emoji', esc(data.emoji)),
+        kvRow('role', esc(data.role)),
+        kvRow('title', esc(data.title)),
+        kvRow('status', esc(data.status)),
+        kvRow('healthScore', esc(data.healthScore)),
+        kvRow('currentModel', esc(data.currentModel)),
+        kvRow('currentBranch', esc(data.currentBranch)),
+        kvRow('activeTask.title', esc(data.activeTask?.title)),
+        kvRow('activeTask.issueUrl', issueHtml),
+        kvRow('lastActivityAt', esc(fmtTime(data.lastActivityAt))),
+      ].join(''),
+    );
+
+    const events = Array.isArray(data.recentEvents) ? data.recentEvents : [];
+    setHtml(eventsEl, events.length ? events.map(eventItem).join('') : '<div class="muted">暂无事件</div>');
+
+    const sources = Array.isArray(data.sourceStatus) ? data.sourceStatus : [];
+    setHtml(sourcesEl, sources.length ? sources.map(sourceItem).join('') : '<div class="muted">暂无数据源状态</div>');
+
+    const md = await fetchJson('/api/v1/markdown-files');
+    if (md.ok) {
+      setHtml(mdEl, md.payload.data.map(mdItem).join(''));
+    } else {
+      setHtml(mdEl, `<div class="status err">加载 markdown allowlist 失败：${esc(md.payload?.error?.message || md.status)}</div>`);
+    }
+  })();
+})();

--- a/src/public/dashboard.js
+++ b/src/public/dashboard.js
@@ -1,0 +1,78 @@
+(function initDashboard() {
+  const { byId, setHtml, fmtTime, fetchJson, esc } = window.oc;
+
+  const agentsEl = byId('agents');
+  const leaderboardEl = byId('leaderboard');
+  const mdEl = byId('mdFiles');
+
+  function dotForStatus(status) {
+    const s = String(status || 'unknown').toLowerCase();
+    if (s === 'active' || s === 'healthy') return 'ok';
+    if (s === 'degraded' || s === 'blocked') return 'warn';
+    if (s === 'offline') return 'err';
+    return '';
+  }
+
+  function agentCard(agent) {
+    const link = '/agents/' + encodeURIComponent(agent.agentId);
+    const dot = dotForStatus(agent.status);
+    const name = (agent.emoji ? agent.emoji + ' ' : '') + (agent.displayName || agent.agentId);
+    const role = agent.role || '—';
+    const title = agent.title || '';
+    const status = agent.status || 'unknown';
+    const score = agent.healthScore ?? '—';
+    return `
+      <a class="card" href="${link}">
+        <div class="name"><span class="dot ${dot}"></span>${esc(name)}</div>
+        <div class="sub">${esc(role)} · ${esc(title)}</div>
+        <div class="sub">状态：${esc(status)} · healthScore：${esc(score)} · 最近：${esc(fmtTime(agent.lastActivityAt))}</div>
+      </a>
+    `;
+  }
+
+  function leaderboardItem(item) {
+    const link = '/agents/' + encodeURIComponent(item.agentId);
+    return `
+      <div class="item">
+        <div class="top">
+          <div><b>#${esc(item.rank)}</b> <a href="${link}">${esc(item.displayName || item.agentId)}</a> <span class="muted">(${esc(item.role || '—')})</span></div>
+          <div class="pill"><span class="dot"></span>score ${esc(item.leaderboardScore ?? '—')}</div>
+        </div>
+        <div class="meta">24h throughput: ${esc(item.throughput24h ?? '—')} · stability: ${esc(item.stabilityScore ?? '—')} · last: ${esc(fmtTime(item.lastActivityAt))}</div>
+      </div>
+    `;
+  }
+
+  function markdownItem(file) {
+    const link = '/markdown/' + encodeURIComponent(file.fileId);
+    return `
+      <div class="item">
+        <div class="top"><div><a href="${link}">${esc(file.name)}</a></div><div class="muted">${esc(Math.round((file.sizeBytes || 0) / 1024))} KB</div></div>
+        <div class="meta">path: ${esc(file.path)} · updated: ${esc(fmtTime(file.updatedAt))}</div>
+      </div>
+    `;
+  }
+
+  (async () => {
+    const agents = await fetchJson('/api/v1/agents?limit=50');
+    if (!agents.ok) {
+      setHtml(agentsEl, `<div class="status err">加载失败：${esc(agents.payload?.error?.message || agents.status)}</div>`);
+    } else {
+      setHtml(agentsEl, agents.payload.data.map(agentCard).join(''));
+    }
+
+    const leaderboard = await fetchJson('/api/v1/leaderboard?window=24h&sortBy=score&limit=20');
+    if (!leaderboard.ok) {
+      setHtml(leaderboardEl, `<div class="status err">加载失败：${esc(leaderboard.payload?.error?.message || leaderboard.status)}</div>`);
+    } else {
+      setHtml(leaderboardEl, leaderboard.payload.data.map(leaderboardItem).join(''));
+    }
+
+    const md = await fetchJson('/api/v1/markdown-files');
+    if (!md.ok) {
+      setHtml(mdEl, `<div class="status err">加载失败：${esc(md.payload?.error?.message || md.status)}</div>`);
+    } else {
+      setHtml(mdEl, md.payload.data.map(markdownItem).join(''));
+    }
+  })();
+})();

--- a/src/public/markdown-editor.js
+++ b/src/public/markdown-editor.js
@@ -1,0 +1,76 @@
+(function initMarkdownEditor() {
+  const { byId, setText, fmtTime, fetchJson, statusClass } = window.oc;
+
+  const fileId = document.body.dataset.fileId;
+
+  const statusEl = byId('status');
+  const metaEl = byId('meta');
+  const contentEl = byId('content');
+  const diffEl = byId('diff');
+  const previewBtn = byId('preview');
+  const saveBtn = byId('save');
+
+  let originalContent = '';
+
+  function setStatus(level, text) {
+    statusEl.className = 'status ' + statusClass(level);
+    setText(statusEl, text);
+  }
+
+  function explainError(payload) {
+    const err = payload?.error;
+    if (!err) return '未知错误';
+    return `${err.code || 'ERROR'}: ${err.message || ''}`;
+  }
+
+  async function load() {
+    setStatus('ok', '加载中…');
+    const res = await fetchJson('/api/v1/markdown-files/' + encodeURIComponent(fileId));
+    if (!res.ok) {
+      setStatus('error', '加载失败：' + explainError(res.payload));
+      diffEl.textContent = JSON.stringify(res.payload, null, 2);
+      return;
+    }
+    originalContent = res.payload.data.content;
+    contentEl.value = originalContent;
+    metaEl.textContent = `updatedAt=${fmtTime(res.payload.data.updatedAt)} · bytes=${res.payload.data.bytes}`;
+    setStatus('ok', 'OK · 已加载');
+    diffEl.textContent = '(preview to see diff)';
+  }
+
+  previewBtn.addEventListener('click', async () => {
+    const next = contentEl.value;
+    const res = await fetchJson('/api/v1/markdown-files/preview-save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fileId, content: next }),
+    });
+    if (!res.ok) {
+      setStatus('error', '预览失败：' + explainError(res.payload));
+      diffEl.textContent = JSON.stringify(res.payload, null, 2);
+      return;
+    }
+    setStatus('ok', res.payload.data.changed ? 'OK · 有变更（可保存）' : 'OK · 无变更');
+    diffEl.textContent = res.payload.data.diff;
+  });
+
+  saveBtn.addEventListener('click', async () => {
+    const next = contentEl.value;
+    const res = await fetchJson('/api/v1/markdown-files/' + encodeURIComponent(fileId), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: next, expectedContent: originalContent }),
+    });
+    if (!res.ok) {
+      setStatus('error', '保存失败：' + explainError(res.payload));
+      diffEl.textContent = JSON.stringify(res.payload, null, 2);
+      return;
+    }
+    originalContent = next;
+    setStatus('ok', res.payload.data.changed ? 'OK · 已保存（有变更）' : 'OK · 已保存（无变更）');
+    diffEl.textContent = res.payload.data.diff;
+    metaEl.textContent = `updatedAt=${fmtTime(res.payload.data.updatedAt)} · bytes=${res.payload.data.bytes}`;
+  });
+
+  load();
+})();

--- a/src/public/markdown-list.js
+++ b/src/public/markdown-list.js
@@ -1,0 +1,33 @@
+(function initMarkdownList() {
+  const { byId, setText, setHtml, fmtTime, fetchJson, esc } = window.oc;
+
+  const statusEl = byId('status');
+  const listEl = byId('list');
+
+  function mdItem(file) {
+    const link = '/markdown/' + encodeURIComponent(file.fileId);
+    return `
+      <div class="item">
+        <div class="top"><div><a href="${link}">${esc(file.name)}</a></div><div class="muted">${esc(Math.round((file.sizeBytes || 0) / 1024))} KB</div></div>
+        <div class="meta">${esc(file.path)} · updated ${esc(fmtTime(file.updatedAt))} · ${file.writable ? 'writable' : 'read-only'}</div>
+      </div>
+    `;
+  }
+
+  (async () => {
+    const md = await fetchJson('/api/v1/markdown-files');
+    if (!md.ok) {
+      statusEl.className = 'status err';
+      setText(statusEl, `加载失败：${md.payload?.error?.message || md.status}`);
+      setHtml(listEl, '');
+      return;
+    }
+
+    statusEl.className = 'status ok';
+    setText(
+      statusEl,
+      `OK · allowlistCount=${md.payload.meta?.allowlistCount ?? md.payload.data.length} · collectedAt=${fmtTime(md.payload.meta?.collectedAt)}`,
+    );
+    setHtml(listEl, md.payload.data.map(mdItem).join(''));
+  })();
+})();

--- a/src/public/shared.js
+++ b/src/public/shared.js
@@ -1,0 +1,59 @@
+(function initShared() {
+  function byId(id) {
+    return document.getElementById(id);
+  }
+
+  function setText(el, text) {
+    if (el) el.textContent = text;
+  }
+
+  function setHtml(el, html) {
+    if (el) el.innerHTML = html;
+  }
+
+  function statusClass(level) {
+    if (level === 'error' || level === 'err') return 'err';
+    if (level === 'warning' || level === 'warn') return 'warn';
+    return 'ok';
+  }
+
+  function fmtTime(value) {
+    if (!value) return '—';
+    try {
+      return new Date(value).toLocaleString();
+    } catch {
+      return String(value);
+    }
+  }
+
+  function esc(value) {
+    return String(value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
+  async function fetchJson(url, options) {
+    const res = await fetch(url, options);
+    const text = await res.text();
+    let payload;
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch {
+      payload = { error: { code: 'INVALID_JSON', message: 'Response was not JSON' }, raw: text };
+    }
+    return { ok: res.ok, status: res.status, payload };
+  }
+
+  window.oc = {
+    byId,
+    setText,
+    setHtml,
+    statusClass,
+    fmtTime,
+    fetchJson,
+    esc,
+  };
+})();

--- a/src/router.js
+++ b/src/router.js
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
 import {
   createNotFound,
   getAgentDetail,
@@ -8,16 +11,41 @@ import {
   readMarkdownFile,
   saveMarkdownFile,
 } from './data.js';
+import {
+  renderAgentPage,
+  renderDashboardPage,
+  renderMarkdownEditorPage,
+  renderMarkdownListPage,
+} from './ui.js';
 
 const AGENT_STATUSES = new Set(['active', 'idle', 'blocked', 'offline', 'unknown']);
 const LEADERBOARD_WINDOWS = new Set(['24h', '7d']);
 const LEADERBOARD_SORT_FIELDS = new Set(['score', 'throughput', 'stability']);
+
+const staticDir = path.resolve(process.cwd(), 'src', 'public');
+const staticAllowlist = new Set(['shared.js', 'dashboard.js', 'agent.js', 'markdown-list.js', 'markdown-editor.js']);
 
 function json(response, statusCode, payload) {
   response.writeHead(statusCode, {
     'Content-Type': 'application/json; charset=utf-8',
   });
   response.end(JSON.stringify(payload, null, 2));
+}
+
+function html(response, statusCode, payload) {
+  response.writeHead(statusCode, {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  response.end(payload);
+}
+
+function javascript(response, statusCode, payload) {
+  response.writeHead(statusCode, {
+    'Content-Type': 'text/javascript; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  response.end(payload);
 }
 
 function createMeta() {
@@ -89,6 +117,47 @@ export async function route(request, response, url) {
   try {
     if (request.method === 'GET' && url.pathname === '/health') {
       json(response, 200, { ok: true });
+      return;
+    }
+
+    if (request.method === 'GET' && url.pathname.startsWith('/static/')) {
+      const fileName = decodeURIComponent(url.pathname.replace('/static/', ''));
+      if (!staticAllowlist.has(fileName)) {
+        javascript(response, 404, `// 404: static asset '${fileName}' not found`);
+        return;
+      }
+
+      const absolutePath = path.resolve(staticDir, fileName);
+      if (!absolutePath.startsWith(`${staticDir}${path.sep}`)) {
+        javascript(response, 403, '// 403: forbidden static asset path');
+        return;
+      }
+
+      const content = await fs.readFile(absolutePath, 'utf8');
+      javascript(response, 200, content);
+      return;
+    }
+
+    // Minimal UI (phase-1 frontend) — pure HTML + fetch() to the read-only APIs.
+    if (request.method === 'GET' && url.pathname === '/') {
+      html(response, 200, renderDashboardPage());
+      return;
+    }
+
+    if (request.method === 'GET' && url.pathname === '/markdown') {
+      html(response, 200, renderMarkdownListPage());
+      return;
+    }
+
+    if (request.method === 'GET' && url.pathname.startsWith('/markdown/')) {
+      const fileId = decodeURIComponent(url.pathname.replace('/markdown/', ''));
+      html(response, 200, renderMarkdownEditorPage(fileId));
+      return;
+    }
+
+    if (request.method === 'GET' && url.pathname.startsWith('/agents/')) {
+      const agentId = decodeURIComponent(url.pathname.replace('/agents/', ''));
+      html(response, 200, renderAgentPage(agentId));
       return;
     }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,236 @@
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function layout({ title, body, headExtra = '', bodyAttrs = '', scripts = [] }) {
+  const scriptTags = scripts.map((src) => `<script src="${src}" defer></script>`).join('\n');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root{
+      --bg:#0b1020; --panel:#111a33; --panel2:#0f1730;
+      --text:#e9edf7; --muted:#9aa7c7; --line:#223055;
+      --ok:#19c37d; --warn:#f59e0b; --err:#ef4444; --link:#60a5fa;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      --sans: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+    }
+    *{ box-sizing:border-box; }
+    body{ margin:0; font-family:var(--sans); background:radial-gradient(1200px 900px at 20% -10%, #1a2a55 0%, transparent 60%), var(--bg); color:var(--text); }
+    a{ color:var(--link); text-decoration:none; }
+    a:hover{ text-decoration:underline; }
+    header{ padding:18px 18px 12px; border-bottom:1px solid var(--line); background:rgba(17,26,51,.65); backdrop-filter: blur(6px); position:sticky; top:0; z-index:10; }
+    header .row{ display:flex; align-items:center; gap:12px; justify-content:space-between; flex-wrap:wrap; }
+    header .title{ font-weight:700; letter-spacing:.2px; }
+    header .crumbs{ color:var(--muted); font-size:13px; }
+    main{ padding:18px; max-width:1200px; margin:0 auto; }
+    .grid{ display:grid; gap:14px; }
+    .grid.cols-2{ grid-template-columns: 1.2fr .8fr; }
+    @media (max-width: 980px){ .grid.cols-2{ grid-template-columns:1fr; } }
+    .panel{ background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03)); border:1px solid var(--line); border-radius:14px; padding:14px; }
+    .panel h2{ margin:0 0 10px; font-size:14px; color:#cfe0ff; letter-spacing:.25px; }
+    .muted{ color:var(--muted); }
+    .pill{ display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border-radius:999px; border:1px solid var(--line); background:rgba(0,0,0,.18); font-size:12px; }
+    .dot{ width:8px; height:8px; border-radius:999px; background:var(--muted); }
+    .dot.ok{ background:var(--ok); }
+    .dot.warn{ background:var(--warn); }
+    .dot.err{ background:var(--err); }
+    .cards{ display:grid; gap:10px; grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    @media (max-width: 980px){ .cards{ grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+    @media (max-width: 560px){ .cards{ grid-template-columns: 1fr; } }
+    .card{ border:1px solid var(--line); border-radius:14px; padding:12px; background:rgba(15,23,48,.7); }
+    .card .name{ font-weight:700; display:flex; gap:8px; align-items:center; }
+    .card .sub{ margin-top:4px; color:var(--muted); font-size:12px; }
+    .kvs{ display:grid; grid-template-columns: 180px 1fr; gap:6px 10px; font-size:13px; }
+    @media (max-width: 560px){ .kvs{ grid-template-columns: 1fr; } }
+    pre{ background:rgba(0,0,0,.25); border:1px solid var(--line); border-radius:12px; padding:12px; overflow:auto; font-family:var(--mono); font-size:12px; line-height:1.5; }
+    textarea{ width:100%; min-height: 260px; border-radius:12px; border:1px solid var(--line); background:rgba(0,0,0,.22); color:var(--text); padding:10px; font-family:var(--mono); font-size:12px; }
+    button{ cursor:pointer; border-radius:12px; border:1px solid var(--line); background:rgba(255,255,255,.06); color:var(--text); padding:10px 12px; font-weight:650; }
+    button:hover{ background:rgba(255,255,255,.09); }
+    .row{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+    .spacer{ flex:1; }
+    .status{ padding:10px 12px; border-radius:12px; border:1px solid var(--line); background:rgba(0,0,0,.18); font-size:13px; }
+    .status.ok{ border-color: rgba(25,195,125,.45); }
+    .status.warn{ border-color: rgba(245,158,11,.45); }
+    .status.err{ border-color: rgba(239,68,68,.45); }
+    .list{ display:grid; gap:8px; }
+    .item{ padding:10px 12px; border-radius:12px; border:1px solid var(--line); background:rgba(15,23,48,.55); }
+    .item .top{ display:flex; gap:10px; align-items:center; justify-content:space-between; }
+    .item .meta{ margin-top:6px; font-size:12px; color:var(--muted); }
+  </style>
+  ${headExtra}
+</head>
+<body ${bodyAttrs}>
+<header>
+  <div class="row">
+    <div>
+      <div class="title">openclaw-monitor</div>
+      <div class="crumbs">${body.crumbs ?? ''}</div>
+    </div>
+    <div class="row">
+      <a class="pill" href="/"><span class="dot ok"></span>Dashboard</a>
+      <a class="pill" href="/markdown"><span class="dot"></span>Markdown</a>
+    </div>
+  </div>
+</header>
+<main>
+  ${body.content}
+</main>
+${scriptTags}
+</body>
+</html>`;
+}
+
+export function renderDashboardPage() {
+  const content = `
+  <div class="grid" style="gap:18px">
+    <div class="panel">
+      <h2>Agent 状态卡片</h2>
+      <div id="agents" class="cards"><div class="muted">加载中…</div></div>
+    </div>
+
+    <div class="grid cols-2">
+      <div class="panel">
+        <h2>积分排行榜</h2>
+        <div id="leaderboard" class="list"><div class="muted">加载中…</div></div>
+      </div>
+      <div class="panel">
+        <h2>Markdown allowlist</h2>
+        <div id="mdFiles" class="list"><div class="muted">加载中…</div></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>说明</h2>
+      <div class="muted">MVP：Dashboard → Agent 详情 → allowlist Markdown 浏览/预览/保存（受控 API）。</div>
+    </div>
+  </div>
+  `;
+
+  return layout({
+    title: 'openclaw-monitor · Dashboard',
+    bodyAttrs: 'data-page="dashboard"',
+    scripts: ['/static/shared.js', '/static/dashboard.js'],
+    body: {
+      crumbs: 'Dashboard',
+      content,
+    },
+  });
+}
+
+export function renderAgentPage(agentId) {
+  const content = `
+  <div class="grid" style="gap:18px">
+    <div class="panel">
+      <h2>Agent 详情</h2>
+      <div id="status" class="status">加载中…</div>
+      <div style="height:10px"></div>
+      <div id="kvs" class="kvs"></div>
+    </div>
+
+    <div class="grid cols-2">
+      <div class="panel">
+        <h2>最近活动 / 事件</h2>
+        <div id="events" class="list"><div class="muted">加载中…</div></div>
+      </div>
+      <div class="panel">
+        <h2>数据源状态</h2>
+        <div id="sources" class="list"><div class="muted">加载中…</div></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Markdown allowlist（受控编辑）</h2>
+      <div id="md" class="list"><div class="muted">加载中…</div></div>
+    </div>
+  </div>
+  `;
+
+  return layout({
+    title: `openclaw-monitor · Agent · ${agentId}`,
+    bodyAttrs: `data-page="agent" data-agent-id="${escapeHtml(agentId)}"`,
+    scripts: ['/static/shared.js', '/static/agent.js'],
+    body: {
+      crumbs: `<a href="/">Dashboard</a> / Agent / ${escapeHtml(agentId)}`,
+      content,
+    },
+  });
+}
+
+export function renderMarkdownListPage() {
+  const content = `
+  <div class="panel">
+    <h2>Markdown allowlist</h2>
+    <div id="status" class="status">加载中…</div>
+    <div style="height:10px"></div>
+    <div id="list" class="list"></div>
+    <div style="height:10px"></div>
+    <div class="muted">只允许编辑 allowlist 中的 docs/*.md 文件；越界路径将返回 FORBIDDEN_PATH。</div>
+  </div>
+  `;
+
+  return layout({
+    title: 'openclaw-monitor · Markdown',
+    bodyAttrs: 'data-page="markdown-list"',
+    scripts: ['/static/shared.js', '/static/markdown-list.js'],
+    body: {
+      crumbs: `<a href="/">Dashboard</a> / Markdown`,
+      content,
+    },
+  });
+}
+
+export function renderMarkdownEditorPage(fileId) {
+  const content = `
+  <div class="panel">
+    <h2>Markdown 编辑（受控）</h2>
+    <div class="row">
+      <div class="pill"><span class="dot"></span><span id="file">${escapeHtml(fileId)}</span></div>
+      <div class="spacer"></div>
+      <a class="pill" href="/markdown"><span class="dot"></span>返回列表</a>
+    </div>
+
+    <div style="height:10px"></div>
+    <div id="status" class="status">加载中…</div>
+
+    <div style="height:12px"></div>
+    <div class="row">
+      <button id="preview">Preview diff</button>
+      <button id="save">Save</button>
+      <div class="spacer"></div>
+      <div class="muted" id="meta"></div>
+    </div>
+
+    <div style="height:10px"></div>
+    <textarea id="content" spellcheck="false"></textarea>
+
+    <div style="height:10px"></div>
+    <div class="panel" style="padding:12px; background:rgba(0,0,0,.12)">
+      <h2 style="margin:0 0 8px">Diff</h2>
+      <pre id="diff">(preview to see diff)</pre>
+    </div>
+
+    <div style="height:10px"></div>
+    <div class="muted">提示：保存会带上 expectedContent 做并发保护；若返回 CONFLICT，请重新加载后再保存。</div>
+  </div>
+  `;
+
+  return layout({
+    title: `openclaw-monitor · Markdown · ${fileId}`,
+    bodyAttrs: `data-page="markdown-editor" data-file-id="${escapeHtml(fileId)}"`,
+    scripts: ['/static/shared.js', '/static/markdown-editor.js'],
+    body: {
+      crumbs: `<a href="/">Dashboard</a> / <a href="/markdown">Markdown</a> / ${escapeHtml(fileId)}`,
+      content,
+    },
+  });
+}

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -164,3 +164,42 @@ test('PUT /api/v1/markdown-files/:fileId rejects non-allowlisted paths', async (
     assert.equal(payload.error.code, 'FORBIDDEN_PATH');
   });
 });
+
+test('GET / serves dashboard UI html', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/`);
+    assert.equal(response.status, 200);
+    const text = await response.text();
+    assert.match(text, /Agent 状态卡片/);
+    assert.match(text, /openclaw-monitor/);
+  });
+});
+
+test('GET /agents/:id serves agent detail UI html', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/agents/buding`);
+    assert.equal(response.status, 200);
+    const text = await response.text();
+    assert.match(text, /Agent 详情/);
+    assert.match(text, /recentEvents|最近活动/);
+  });
+});
+
+test('GET /markdown serves markdown list UI html', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/markdown`);
+    assert.equal(response.status, 200);
+    const text = await response.text();
+    assert.match(text, /Markdown allowlist/);
+  });
+});
+
+test('GET /markdown/:fileId serves markdown editor UI html', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/markdown/${encodeURIComponent(markdownFileId)}`);
+    assert.equal(response.status, 200);
+    const text = await response.text();
+    assert.match(text, /Markdown 编辑/);
+    assert.match(text, /Preview diff/);
+  });
+});


### PR DESCRIPTION
Closes #34\n\n### What\n- Adds minimal HTML UI routes:  dashboard →  detail\n- Adds allowlist Markdown UI:  list →  read/preview diff/save\n- Static JS served via  (allowlisted)\n\n### How to test\n- 
> openclaw-monitor@0.1.0 test
> NODE_ENV=test node --test test/*.test.js

TAP version 13
# openclaw-monitor api listening on http://127.0.0.1:0
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /api/v1/agents returns dashboard cards
ok 1 - GET /api/v1/agents returns dashboard cards
  ---
  duration_ms: 27.904724
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /api/v1/agents rejects invalid limit
ok 2 - GET /api/v1/agents rejects invalid limit
  ---
  duration_ms: 6.954042
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /api/v1/leaderboard returns ranked entries with window metadata
ok 3 - GET /api/v1/leaderboard returns ranked entries with window metadata
  ---
  duration_ms: 4.330215
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /api/v1/leaderboard rejects unsupported sort field
ok 4 - GET /api/v1/leaderboard rejects unsupported sort field
  ---
  duration_ms: 5.029295
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /api/v1/agents/:id returns detail payload for known agent
ok 5 - GET /api/v1/agents/:id returns detail payload for known agent
  ---
  duration_ms: 4.48836
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /api/v1/agents/:id returns 404 envelope for unknown agent
ok 6 - GET /api/v1/agents/:id returns 404 envelope for unknown agent
  ---
  duration_ms: 3.391746
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /api/v1/markdown-files lists allowlisted markdown files
ok 7 - GET /api/v1/markdown-files lists allowlisted markdown files
  ---
  duration_ms: 3.641539
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /api/v1/markdown-files/:fileId returns markdown content
ok 8 - GET /api/v1/markdown-files/:fileId returns markdown content
  ---
  duration_ms: 3.855107
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: POST /api/v1/markdown-files/preview-save returns diff before save
ok 9 - POST /api/v1/markdown-files/preview-save returns diff before save
  ---
  duration_ms: 13.540469
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: PUT /api/v1/markdown-files/:fileId saves markdown with expected content guard
ok 10 - PUT /api/v1/markdown-files/:fileId saves markdown with expected content guard
  ---
  duration_ms: 9.682046
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: PUT /api/v1/markdown-files/:fileId rejects non-allowlisted paths
ok 11 - PUT /api/v1/markdown-files/:fileId rejects non-allowlisted paths
  ---
  duration_ms: 2.820678
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET / serves dashboard UI html
ok 12 - GET / serves dashboard UI html
  ---
  duration_ms: 4.080512
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /agents/:id serves agent detail UI html
ok 13 - GET /agents/:id serves agent detail UI html
  ---
  duration_ms: 2.321023
  type: 'test'
  ...
# openclaw-monitor api listening on http://127.0.0.1:0
# Subtest: GET /markdown serves markdown list UI html
ok 14 - GET /markdown serves markdown list UI html
  ---
  duration_ms: 2.266846
  type: 'test'
  ...
# Subtest: GET /markdown/:fileId serves markdown editor UI html
ok 15 - GET /markdown/:fileId serves markdown editor UI html
  ---
  duration_ms: 2.218208
  type: 'test'
  ...
1..15
# tests 15
# suites 0
# pass 15
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 235.344057\n- 
> openclaw-monitor@0.1.0 start
> node src/server.js then open \n  - Click an Agent card to enter detail\n  - Open Markdown allowlist, preview diff, and save\n\n### Safety\n- Editing only via backend allowlist + FORBIDDEN_PATH errors\n- Save uses  optimistic guard