### PR TITLE
feat(web): agent detail + markdown file management (P2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ npm test
 npm start
 ```
 
-API base: `http://127.0.0.1:3000/api/v1/...`
+API base (preferred): `http://127.0.0.1:3000/api/...`
 
-## Frontend (Dashboard)
+Back-compat (legacy): `http://127.0.0.1:3000/api/v1/...`
+
+## Frontend (Dashboard + Agent detail + Markdown)
 
 ```bash
 cd web
@@ -22,3 +24,9 @@ npm run dev
 ```
 
 The Vite dev server proxies `/api` to `http://127.0.0.1:3000`.
+
+Routes (frontend):
+- `/` dashboard
+- `/agents/:agentId` agent detail
+- `/markdown` markdown allowlist list
+- `/markdown/:fileId` markdown editor (preview diff + save)

--- a/web/README.md
+++ b/web/README.md
@@ -7,10 +7,20 @@ npm install
 npm run dev
 ```
 
-By default it calls backend via the Vite proxy:
+By default it calls backend via the Vite proxy (`/api` → `http://127.0.0.1:3000`):
+
+- Dashboard aggregator: `GET /api/dashboard`
+- Agent detail: `GET /api/agents/:agentId`
+- Markdown allowlist:
+  - `GET /api/markdown/files`
+  - `GET /api/markdown/read?fileId=...`
+  - `POST /api/markdown/preview`
+  - `POST /api/markdown/save`
+
+Back-compat fallback (legacy):
 - `/api/v1/agents`
 - `/api/v1/leaderboard`
-- `/api/v1/agents/:agentId` (for recent events + source status)
+- `/api/v1/agents/:agentId` (recent events + source status)
 
 Environment:
 - `VITE_API_BASE` (default `/api`)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,43 @@
 import DashboardPage from './pages/DashboardPage'
+import AgentPage from './pages/AgentPage'
+import MarkdownEditorPage from './pages/MarkdownEditorPage'
+import MarkdownListPage from './pages/MarkdownListPage'
+
+function decodePathPart(value: string) {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
 
 export default function App() {
-  return <DashboardPage />
+  const pathname = window.location.pathname || '/'
+  const parts = pathname.split('/').filter(Boolean)
+
+  if (parts.length === 0) return <DashboardPage />
+
+  if (parts[0] === 'agents' && parts[1]) {
+    return <AgentPage agentId={decodePathPart(parts[1])} />
+  }
+
+  if (parts[0] === 'markdown' && parts.length === 1) {
+    return <MarkdownListPage />
+  }
+
+  if (parts[0] === 'markdown' && parts[1]) {
+    return <MarkdownEditorPage fileId={decodePathPart(parts[1])} />
+  }
+
+  return (
+    <div className="page">
+      <div className="banner error">
+        <div className="bannerTitle">Not found</div>
+        <div className="bannerBody">Unknown route: {pathname}</div>
+        <div className="bannerHint">
+          <a href="/">Go back to dashboard</a>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/web/src/components/AgentCardsRow.tsx
+++ b/web/src/components/AgentCardsRow.tsx
@@ -13,7 +13,12 @@ export default function AgentCardsRow({ agents }: { agents: AgentSummary[] }) {
   return (
     <div className="agentsRow" role="list">
       {agents.map((a) => (
-        <article key={a.id} className="agentCard" role="listitem">
+        <a
+          key={a.id}
+          className="agentCard agentCardLink"
+          role="listitem"
+          href={`/agents/${encodeURIComponent(a.id)}`}
+        >
           <div className="agentTop">
             <div className="agentName">{a.name || a.id}</div>
             <div className={`agentStatus s-${a.status || 'unknown'}`}>{a.status || 'unknown'}</div>
@@ -35,7 +40,7 @@ export default function AgentCardsRow({ agents }: { agents: AgentSummary[] }) {
           <div className="agentTask" title={a.currentTask || ''}>
             {a.currentTask ? a.currentTask : <span className="muted">No current task</span>}
           </div>
-        </article>
+        </a>
       ))}
     </div>
   )

--- a/web/src/lib/fetchJson.ts
+++ b/web/src/lib/fetchJson.ts
@@ -13,6 +13,9 @@ export async function fetchJson<T>(
   opts?: {
     timeoutMs?: number
     signal?: AbortSignal
+    method?: string
+    headers?: Record<string, string>
+    body?: BodyInit | null
   }
 ): Promise<T> {
   const timeoutMs = opts?.timeoutMs ?? 10_000
@@ -24,8 +27,9 @@ export async function fetchJson<T>(
 
   try {
     const res = await fetch(url, {
-      method: 'GET',
-      headers: { 'Accept': 'application/json' },
+      method: opts?.method ?? 'GET',
+      headers: { 'Accept': 'application/json', ...(opts?.headers ?? {}) },
+      body: opts?.body,
       signal
     })
 

--- a/web/src/pages/AgentPage.tsx
+++ b/web/src/pages/AgentPage.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import SectionCard from '../components/SectionCard'
+import StatusBadge from '../components/StatusBadge'
+import type { DashboardHealth } from '../lib/dashboardTypes'
+import { API_BASE } from '../lib/config'
+import { fetchJson, HttpError } from '../lib/fetchJson'
+
+type Meta = {
+  partial?: boolean
+  collectedAt?: string
+  degradeReasons?: string[]
+  sourceLagMs?: number
+}
+
+type SourceState = {
+  name: string
+  status: 'ok' | 'degraded' | 'unavailable'
+  message?: string
+  collectedAt?: string
+  updatedAt?: string | null
+}
+
+type TaskItem = {
+  id: string
+  title: string
+  status?: string
+  issue_url?: string
+  priority?: string
+  updated_at?: string
+}
+
+type EventItem = {
+  id?: string
+  at?: string
+  kind?: string
+  title?: string
+  summary?: string
+  severity?: 'info' | 'warning' | 'error'
+}
+
+type MarkdownFile = {
+  fileId: string
+  name: string
+  path: string
+  updatedAt?: string
+  sizeBytes?: number
+  writable?: boolean
+}
+
+type AgentDetail = {
+  agentId: string
+  displayName?: string
+  emoji?: string
+  role?: string
+  score?: number
+  status?: string
+  lastActivityAt?: string | null
+  activeTask?: {
+    taskId?: string
+    title?: string
+    issueUrl?: string
+    priority?: string
+    status?: string
+    updatedAt?: string | null
+  } | null
+  tasks?: TaskItem[]
+  recentEvents?: EventItem[]
+  sourceStatus?: SourceState[]
+  markdownFiles?: MarkdownFile[]
+}
+
+type AgentDetailResponse = { data: AgentDetail; meta?: Meta }
+
+function fmtTime(ts?: string | null) {
+  if (!ts) return '—'
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ts
+  return d.toLocaleString()
+}
+
+function healthFromMeta(meta?: Meta): DashboardHealth {
+  if (meta?.partial) return 'partial'
+  if ((meta?.degradeReasons || []).length) return 'degraded'
+  return 'ok'
+}
+
+export default function AgentPage({ agentId }: { agentId: string }) {
+  const [data, setData] = useState<AgentDetailResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null)
+
+  const abortRef = useRef<AbortController | null>(null)
+
+  const apiBaseLabel = useMemo(() => API_BASE, [])
+
+  const meta = data?.meta
+  const health = healthFromMeta(meta)
+
+  async function loadOnce() {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const url = `${API_BASE.replace(/\/$/, '')}/agents/${encodeURIComponent(agentId)}`
+      const res = await fetchJson<AgentDetailResponse>(url, { timeoutMs: 10_000, signal: controller.signal })
+      setData(res)
+      setLastUpdatedAt(new Date().toISOString())
+      setError(null)
+    } catch (e) {
+      if (controller.signal.aborted) return
+      if (e instanceof HttpError) {
+        setError(`${e.message}${e.bodyText ? `\n${e.bodyText}` : ''}`)
+      } else if (e instanceof Error) {
+        setError(e.message)
+      } else {
+        setError('Unknown error')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadOnce()
+    return () => abortRef.current?.abort()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentId])
+
+  const agent = data?.data
+  const markdownFiles = agent?.markdownFiles || []
+  const recentEvents = agent?.recentEvents || []
+  const tasks = agent?.tasks || []
+  const sources = agent?.sourceStatus || []
+
+  return (
+    <div className="page">
+      <header className="topbar">
+        <div className="brand">
+          <div className="title">openclaw-monitor</div>
+          <div className="subtitle">Agent detail</div>
+        </div>
+
+        <div className="controls">
+          <div className="metaLine">
+            <span className="muted">api</span>
+            <code className="code">{apiBaseLabel}</code>
+          </div>
+          <div className="metaLine">
+            <span className="muted">agent</span>
+            <code className="code">{agentId}</code>
+            <span className="sep">·</span>
+            <StatusBadge health={health} />
+            <span className="sep">·</span>
+            <span className="muted">updated</span>
+            <span>{fmtTime(lastUpdatedAt || meta?.collectedAt)}</span>
+          </div>
+          <div className="btnRow">
+            <a className="btn" href="/">
+              Back to dashboard
+            </a>{' '}
+            <button className="btn" onClick={() => void loadOnce()} disabled={loading}>
+              {loading ? 'Loading…' : 'Refresh'}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="banner error">
+          <div className="bannerTitle">Failed to load agent</div>
+          <pre className="bannerBody">{error}</pre>
+        </div>
+      ) : null}
+
+      {health === 'partial' || health === 'degraded' ? (
+        <div className={`banner ${health === 'partial' ? 'partial' : 'degraded'}`}>
+          <div className="bannerTitle">{health.toUpperCase()} data</div>
+          <div className="bannerBody">
+            Data may be incomplete.
+            {(meta?.degradeReasons || []).length ? `\nreasons: ${(meta?.degradeReasons || []).join(', ')}` : ''}
+          </div>
+        </div>
+      ) : null}
+
+      <main className="grid">
+        <SectionCard title="Summary" right={<span className="muted">/api/agents/:id</span>}>
+          <div className="kvGrid">
+            <KV k="display" v={`${agent?.emoji || ''} ${agent?.displayName || agent?.agentId || '—'}`} />
+            <KV k="role" v={agent?.role || '—'} />
+            <KV k="status" v={agent?.status || '—'} />
+            <KV k="score" v={typeof agent?.score === 'number' ? String(agent?.score) : '—'} />
+            <KV k="lastActivity" v={fmtTime(agent?.lastActivityAt)} />
+            <KV k="activeTask" v={agent?.activeTask?.title || '—'} />
+            <KV k="activeTask.status" v={agent?.activeTask?.status || '—'} />
+            <KV k="activeTask.issue" v={agent?.activeTask?.issueUrl ? <a href={agent.activeTask.issueUrl}>{agent.activeTask.issueUrl}</a> : '—'} />
+          </div>
+        </SectionCard>
+
+        <div className="gridCols2">
+          <SectionCard title="Markdown allowlist" right={<a className="muted" href="/markdown">open</a>}>
+            {markdownFiles.length ? (
+              <ul className="list">
+                {markdownFiles.map((f) => (
+                  <li key={f.fileId} className="listItem">
+                    <div className="listTop">
+                      <span className="title">
+                        <a href={`/markdown/${encodeURIComponent(f.fileId)}`}>{f.name}</a>
+                      </span>
+                      <span className="muted">{fmtTime(f.updatedAt)}</span>
+                    </div>
+                    <div className="detail muted">{f.path}</div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="empty">No allowlisted markdown files.</div>
+            )}
+          </SectionCard>
+
+          <SectionCard title="Source status" right={<span className="muted">meta.partial = {String(meta?.partial ?? false)}</span>}>
+            {sources.length ? (
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>source</th>
+                    <th>status</th>
+                    <th>updated</th>
+                    <th>message</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sources.map((s) => (
+                    <tr key={s.name}>
+                      <td>{s.name}</td>
+                      <td>{s.status}</td>
+                      <td>{fmtTime(s.updatedAt || s.collectedAt)}</td>
+                      <td className="muted">{s.message || '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <div className="empty">No source status.</div>
+            )}
+          </SectionCard>
+        </div>
+
+        <div className="gridCols2">
+          <SectionCard title="Recent events" right={<span className="muted">latest 50</span>}>
+            {recentEvents.length ? (
+              <ul className="list">
+                {recentEvents.slice(0, 20).map((ev, idx) => (
+                  <li key={`${ev.at || idx}`} className={`listItem sev-${ev.severity === 'warning' ? 'warn' : ev.severity || 'info'}`}>
+                    <div className="listTop">
+                      <span className="ts">{fmtTime(ev.at)}</span>
+                      <span className="title">{ev.title || ev.kind || 'event'}</span>
+                    </div>
+                    <div className="detail">{ev.summary || '—'}</div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="empty">No events.</div>
+            )}
+          </SectionCard>
+
+          <SectionCard title="Tasks" right={<span className="muted">latest 50</span>}>
+            {tasks.length ? (
+              <ul className="list">
+                {tasks.slice(0, 20).map((t) => (
+                  <li key={t.id} className="listItem">
+                    <div className="listTop">
+                      <span className="title">{t.title}</span>
+                      <span className="muted">{t.status || '—'}</span>
+                    </div>
+                    <div className="detail muted">
+                      {t.issue_url ? (
+                        <a href={t.issue_url} target="_blank" rel="noreferrer">
+                          {t.issue_url}
+                        </a>
+                      ) : (
+                        '—'
+                      )}
+                      {' · updated '}
+                      {fmtTime(t.updated_at)}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="empty">No tasks.</div>
+            )}
+          </SectionCard>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function KV({ k, v }: { k: string; v: any }) {
+  return (
+    <div className="kvRow">
+      <div className="k">{k}</div>
+      <div className="v">{v}</div>
+    </div>
+  )
+}

--- a/web/src/pages/MarkdownEditorPage.tsx
+++ b/web/src/pages/MarkdownEditorPage.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import SectionCard from '../components/SectionCard'
+import StatusBadge from '../components/StatusBadge'
+import type { DashboardHealth } from '../lib/dashboardTypes'
+import { API_BASE } from '../lib/config'
+import { fetchJson, HttpError } from '../lib/fetchJson'
+
+type Meta = {
+  partial?: boolean
+  collectedAt?: string
+  degradeReasons?: string[]
+  allowlistRoot?: string
+}
+
+type ErrorEnvelope = {
+  error: { code?: string; message?: string; retryable?: boolean; details?: any }
+  meta?: Meta
+}
+
+type ReadData = { fileId: string; path: string; content: string; updatedAt?: string; bytes?: number }
+
+type ReadResponse = { data: ReadData; meta?: Meta }
+
+type PreviewData = {
+  fileId: string
+  path: string
+  changed: boolean
+  diff: string
+  previousBytes?: number
+  nextBytes?: number
+}
+
+type PreviewResponse = { data: PreviewData; meta?: Meta }
+
+type SaveData = {
+  fileId: string
+  path: string
+  saved: boolean
+  changed: boolean
+  diff: string
+  updatedAt?: string
+  bytes?: number
+}
+
+type SaveResponse = { data: SaveData; meta?: Meta }
+
+function fmtTime(ts?: string) {
+  if (!ts) return '—'
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ts
+  return d.toLocaleString()
+}
+
+function healthFromMeta(meta?: Meta): DashboardHealth {
+  if (meta?.partial) return 'partial'
+  if ((meta?.degradeReasons || []).length) return 'degraded'
+  return 'ok'
+}
+
+function explain(e: any): string {
+  if (!e) return 'Unknown error'
+  if (typeof e === 'string') return e
+  if (e?.error?.code || e?.error?.message) return `${e.error.code || 'ERROR'}: ${e.error.message || ''}`
+  return e instanceof Error ? e.message : String(e)
+}
+
+function parseErrorEnvelope(bodyText?: string): { code?: string; message?: string } | null {
+  if (!bodyText) return null
+  try {
+    const parsed = JSON.parse(bodyText)
+    if (parsed?.error?.code || parsed?.error?.message) {
+      return { code: parsed.error.code, message: parsed.error.message }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function formatHttpError(e: HttpError): string {
+  const parsed = parseErrorEnvelope(e.bodyText)
+  if (!parsed) return `${e.message}${e.bodyText ? `\n${e.bodyText}` : ''}`
+
+  const code = parsed.code || 'ERROR'
+  const msg = parsed.message || ''
+
+  const hints: Record<string, string> = {
+    CONFLICT: 'Conflict: content changed since load/preview. Click Reload, then re-apply changes and Save again.',
+    FORBIDDEN_PATH: 'Forbidden: this path is not in the markdown allowlist.',
+    NOT_FOUND: 'Not found: file is missing or fileId is invalid.'
+  }
+
+  return `${code}: ${msg}${hints[code] ? `\nHint: ${hints[code]}` : ''}`
+}
+
+export default function MarkdownEditorPage({ fileId }: { fileId: string }) {
+  const [meta, setMeta] = useState<Meta | undefined>(undefined)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [status, setStatus] = useState<string>('Loading…')
+  const [originalContent, setOriginalContent] = useState<string>('')
+  const [content, setContent] = useState<string>('')
+  const [diff, setDiff] = useState<string>('(preview to see diff)')
+  const [updatedAt, setUpdatedAt] = useState<string | undefined>(undefined)
+  const [bytes, setBytes] = useState<number | undefined>(undefined)
+
+  const abortRef = useRef<AbortController | null>(null)
+  const apiBaseLabel = useMemo(() => API_BASE, [])
+
+  const health = healthFromMeta(meta)
+
+  async function readOnce() {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setLoading(true)
+    setError(null)
+    setStatus('Loading…')
+
+    try {
+      const url = `${API_BASE.replace(/\/$/, '')}/markdown/read?fileId=${encodeURIComponent(fileId)}`
+      const res = await fetchJson<ReadResponse>(url, { timeoutMs: 10_000, signal: controller.signal })
+      setMeta(res.meta)
+      setOriginalContent(res.data.content)
+      setContent(res.data.content)
+      setUpdatedAt(res.data.updatedAt)
+      setBytes(res.data.bytes)
+      setDiff('(preview to see diff)')
+      setStatus('OK · loaded')
+    } catch (e) {
+      if (controller.signal.aborted) return
+      if (e instanceof HttpError) {
+        setError(formatHttpError(e))
+      } else if (e instanceof Error) {
+        setError(e.message)
+      } else {
+        setError('Unknown error')
+      }
+      setStatus('Failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function previewOnce() {
+    setStatus('Previewing…')
+    setError(null)
+    try {
+      const url = `${API_BASE.replace(/\/$/, '')}/markdown/preview`
+      const res = await fetchJson<PreviewResponse>(url, {
+        timeoutMs: 10_000,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fileId, content })
+      })
+      setMeta(res.meta)
+      setDiff(res.data.diff)
+      setStatus(res.data.changed ? 'OK · changed (ready to save)' : 'OK · no changes')
+    } catch (e) {
+      if (e instanceof HttpError) {
+        setError(formatHttpError(e))
+      } else {
+        setError(explain(e))
+      }
+      setStatus('Preview failed')
+    }
+  }
+
+  async function saveOnce() {
+    setStatus('Saving…')
+    setError(null)
+    try {
+      const url = `${API_BASE.replace(/\/$/, '')}/markdown/save`
+      const res = await fetchJson<SaveResponse | ErrorEnvelope>(url, {
+        timeoutMs: 10_000,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fileId, content, expectedContent: originalContent })
+      })
+
+      // if backend returns error envelope with 200 (shouldn't), handle anyway
+      if ((res as any)?.error) {
+        throw new Error(explain(res))
+      }
+
+      const okRes = res as SaveResponse
+      setMeta(okRes.meta)
+      setDiff(okRes.data.diff)
+      setOriginalContent(content)
+      setUpdatedAt(okRes.data.updatedAt)
+      setBytes(okRes.data.bytes)
+      setStatus(okRes.data.changed ? 'OK · saved (changed)' : 'OK · saved (no changes)')
+    } catch (e) {
+      if (e instanceof HttpError) {
+        setError(formatHttpError(e))
+      } else {
+        setError(explain(e))
+      }
+      setStatus('Save failed')
+    }
+  }
+
+  useEffect(() => {
+    void readOnce()
+    return () => abortRef.current?.abort()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileId])
+
+  return (
+    <div className="page">
+      <header className="topbar">
+        <div className="brand">
+          <div className="title">openclaw-monitor</div>
+          <div className="subtitle">Markdown editor (allowlist)</div>
+        </div>
+
+        <div className="controls">
+          <div className="metaLine">
+            <span className="muted">api</span>
+            <code className="code">{apiBaseLabel}</code>
+          </div>
+          <div className="metaLine">
+            <span className="muted">file</span>
+            <code className="code">{fileId}</code>
+          </div>
+          <div className="metaLine">
+            <StatusBadge health={health} />
+            <span className="sep">·</span>
+            <span className="muted">updated</span>
+            <span>{fmtTime(updatedAt || meta?.collectedAt)}</span>
+          </div>
+          <div className="btnRow">
+            <a className="btn" href="/markdown">
+              Back to list
+            </a>{' '}
+            <button className="btn" onClick={() => void readOnce()} disabled={loading}>
+              {loading ? 'Loading…' : 'Reload'}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="banner error">
+          <div className="bannerTitle">Markdown operation failed</div>
+          <pre className="bannerBody">{error}</pre>
+        </div>
+      ) : null}
+
+      {health === 'partial' || health === 'degraded' ? (
+        <div className={`banner ${health === 'partial' ? 'partial' : 'degraded'}`}>
+          <div className="bannerTitle">{health.toUpperCase()} data</div>
+          <div className="bannerBody">
+            Data may be incomplete.
+            {(meta?.degradeReasons || []).length ? `\nreasons: ${(meta?.degradeReasons || []).join(', ')}` : ''}
+          </div>
+        </div>
+      ) : null}
+
+      <main className="grid">
+        <SectionCard title="Editor" right={<span className="muted">{status}</span>}>
+          <div className="editorRow">
+            <button className="btn" onClick={() => void previewOnce()} disabled={loading}>
+              Preview diff
+            </button>
+            <button className="btn" onClick={() => void saveOnce()} disabled={loading}>
+              Save
+            </button>
+            <span className="muted">
+              bytes: {typeof bytes === 'number' ? bytes : '—'} · expectedContent guard enabled
+            </span>
+          </div>
+
+          <textarea
+            className="mdTextarea"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            spellCheck={false}
+          />
+
+          <div style={{ height: 10 }} />
+          <div className="muted">Diff</div>
+          <pre className="diffBox">{diff}</pre>
+        </SectionCard>
+      </main>
+    </div>
+  )
+}

--- a/web/src/pages/MarkdownListPage.tsx
+++ b/web/src/pages/MarkdownListPage.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import SectionCard from '../components/SectionCard'
+import StatusBadge from '../components/StatusBadge'
+import type { DashboardHealth } from '../lib/dashboardTypes'
+import { API_BASE } from '../lib/config'
+import { fetchJson, HttpError } from '../lib/fetchJson'
+
+type Meta = {
+  partial?: boolean
+  collectedAt?: string
+  degradeReasons?: string[]
+  allowlistRoot?: string
+  allowlistCount?: number
+}
+
+type MarkdownFile = {
+  fileId: string
+  name: string
+  path: string
+  updatedAt?: string
+  sizeBytes?: number
+  writable?: boolean
+}
+
+type FilesResponse = { data: MarkdownFile[]; meta?: Meta }
+
+function fmtTime(ts?: string) {
+  if (!ts) return '—'
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ts
+  return d.toLocaleString()
+}
+
+function healthFromMeta(meta?: Meta): DashboardHealth {
+  if (meta?.partial) return 'partial'
+  if ((meta?.degradeReasons || []).length) return 'degraded'
+  return 'ok'
+}
+
+export default function MarkdownListPage() {
+  const [data, setData] = useState<FilesResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null)
+
+  const abortRef = useRef<AbortController | null>(null)
+  const apiBaseLabel = useMemo(() => API_BASE, [])
+
+  const meta = data?.meta
+  const health = healthFromMeta(meta)
+
+  async function loadOnce() {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const url = `${API_BASE.replace(/\/$/, '')}/markdown/files`
+      const res = await fetchJson<FilesResponse>(url, { timeoutMs: 10_000, signal: controller.signal })
+      setData(res)
+      setLastUpdatedAt(new Date().toISOString())
+    } catch (e) {
+      if (controller.signal.aborted) return
+      if (e instanceof HttpError) {
+        setError(`${e.message}${e.bodyText ? `\n${e.bodyText}` : ''}`)
+      } else if (e instanceof Error) {
+        setError(e.message)
+      } else {
+        setError('Unknown error')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadOnce()
+    return () => abortRef.current?.abort()
+  }, [])
+
+  const files = data?.data || []
+
+  return (
+    <div className="page">
+      <header className="topbar">
+        <div className="brand">
+          <div className="title">openclaw-monitor</div>
+          <div className="subtitle">Markdown allowlist</div>
+        </div>
+
+        <div className="controls">
+          <div className="metaLine">
+            <span className="muted">api</span>
+            <code className="code">{apiBaseLabel}</code>
+          </div>
+          <div className="metaLine">
+            <StatusBadge health={health} />
+            <span className="sep">·</span>
+            <span className="muted">updated</span>
+            <span>{fmtTime(lastUpdatedAt || meta?.collectedAt)}</span>
+          </div>
+          <div className="btnRow">
+            <a className="btn" href="/">
+              Back to dashboard
+            </a>{' '}
+            <button className="btn" onClick={() => void loadOnce()} disabled={loading}>
+              {loading ? 'Loading…' : 'Refresh'}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="banner error">
+          <div className="bannerTitle">Failed to load markdown files</div>
+          <pre className="bannerBody">{error}</pre>
+        </div>
+      ) : null}
+
+      {health === 'partial' || health === 'degraded' ? (
+        <div className={`banner ${health === 'partial' ? 'partial' : 'degraded'}`}>
+          <div className="bannerTitle">{health.toUpperCase()} data</div>
+          <div className="bannerBody">Some sources are stale/unavailable. UI should still be usable.</div>
+        </div>
+      ) : null}
+
+      <main className="grid">
+        <SectionCard
+          title="Files"
+          right={
+            <span className="muted">
+              allowlistRoot={meta?.allowlistRoot || 'docs'} · count={meta?.allowlistCount ?? files.length}
+            </span>
+          }
+        >
+          {files.length ? (
+            <ul className="list">
+              {files.map((f) => (
+                <li key={f.fileId} className="listItem">
+                  <div className="listTop">
+                    <span className="title">
+                      <a href={`/markdown/${encodeURIComponent(f.fileId)}`}>{f.name}</a>
+                    </span>
+                    <span className="muted">{fmtTime(f.updatedAt)}</span>
+                  </div>
+                  <div className="detail muted">
+                    {f.path} · {typeof f.sizeBytes === 'number' ? `${Math.round(f.sizeBytes / 1024)} KB` : '—'} ·{' '}
+                    {f.writable ? 'writable' : 'read-only'}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="empty">No allowlisted files.</div>
+          )}
+        </SectionCard>
+
+        <SectionCard title="Notes" right={<span className="muted">安全边界</span>}>
+          <div className="empty">
+            Only allowlisted markdown files can be read/saved. Out-of-scope paths should surface a clear
+            FORBIDDEN_PATH error.
+          </div>
+        </SectionCard>
+      </main>
+    </div>
+  )
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -41,12 +41,14 @@ body {
 .sep { opacity: 0.5; }
 .btnRow { margin-top: 8px; }
 .btn {
+  display: inline-block;
   padding: 8px 12px;
   border-radius: 10px;
   border: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.06);
   color: var(--text);
   cursor: pointer;
+  text-decoration: none;
 }
 .btn:disabled { opacity: 0.6; cursor: not-allowed; }
 
@@ -161,3 +163,63 @@ body {
 
 .empty { color: var(--muted); font-size: 12px; padding: 6px 0; }
 .muted { color: var(--muted); }
+
+/* --- Added for Agent detail + Markdown management pages (P2) --- */
+.agentCardLink { color: inherit; text-decoration: none; }
+.agentCardLink:hover { border-color: rgba(255,255,255,0.22); background: rgba(255,255,255,0.05); }
+
+.gridCols2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+@media (max-width: 1100px) {
+  .gridCols2 { grid-template-columns: 1fr; }
+}
+
+.kvGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+@media (max-width: 800px) {
+  .kvGrid { grid-template-columns: 1fr; }
+}
+.kvRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.02);
+  font-size: 12px;
+}
+.kvRow .k { color: var(--muted); }
+.kvRow .v { color: rgba(255,255,255,0.86); }
+
+.editorRow { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 10px; }
+.mdTextarea {
+  width: 100%;
+  min-height: 360px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(0,0,0,0.25);
+  color: rgba(255,255,255,0.92);
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 12px;
+  line-height: 1.45;
+}
+.diffBox {
+  overflow: auto;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(0,0,0,0.25);
+  color: rgba(255,255,255,0.88);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre;
+}


### PR DESCRIPTION
Closes #39\n\nWhat\n- Adds web routes: /agents/:agentId, /markdown, /markdown/:fileId\n- Agent detail shows identity/role/status/score/last activity/task summary + tasks/events + source status\n- Markdown allowlist UI supports read, preview diff, save (expectedContent guard) with clear error hints\n- Updates README docs; extends fetchJson to support POST\n\nChecks\n- backend: npm run check && npm test\n- web: cd web && npm install && npm run typecheck\n\nNotes\n- Degraded/partial meta is surfaced via StatusBadge + banner