### PR TITLE
feat: normalize events + actionable timeline (dashboard/agent) (#54)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,38 @@ Frontend (web/)
 - `degradeReasons`: 降级原因
 - `freshness`: 每个数据源的 lag/mtime 计算
 
-## 4. Markdown 管理的安全边界
+## 4. Events & Timeline semantics
+
+Backend 从 `events.json` 读取 **raw events**，并在聚合接口中输出两类结构：
+
+- `events`: 规范化后的事件列表（用于 Event 面板）
+- `timeline`: 去噪后的关键时间线（用于 Timeline 面板）
+
+### 4.1 Event schema (normalized)
+
+在 `/api/dashboard` 与 `/api/agents/:id` 中，`events[]` 至少补齐以下字段（保持向后兼容：原始字段仍保留）：
+
+- `at` (ISO string | null)
+- `kind` (string)
+- `severity` (`info` | `warn` | `error`)
+- `agentId` (string | null)
+- `source` (string, default `runtime`)
+- `title` (string)
+- `summary` (string)
+
+### 4.2 Ordering
+
+- `events`: **按 `at` 倒序**（最新在前；缺失 `at` 的按输入顺序稳定排序）
+- `timeline`: **按 `at` 正序**（最旧在前，方便 UI 展示状态演进）
+
+### 4.3 De-noise / merge
+
+对明显噪声事件（例如 `worker-tick` / `worker-skip`）进行连续合并，并在合并项上补充：
+
+- `count`：合并数量
+- `atEnd`：合并覆盖的最早时间（可选）
+
+## 5. Markdown 管理的安全边界
 
 写操作（保存）必须满足：
 
@@ -55,7 +86,7 @@ Frontend (web/)
 
 策略配置：`config/markdown-boundaries.json`
 
-## 5. Frontend
+## 6. Frontend
 
 - Vite + React，组件在 `web/src/components/`
 - 页面：
@@ -64,7 +95,7 @@ Frontend (web/)
   - `MarkdownListPage.tsx`
   - `MarkdownEditorPage.tsx`
 
-## 6. Non-goals
+## 7. Non-goals
 
 - 本项目当前不提供：认证/鉴权、多租户、写操作运维闭环。
 - Phase 2 / 3 目标是把“观察面与受控写入”做好，后续再扩展。

--- a/src/data.js
+++ b/src/data.js
@@ -235,6 +235,183 @@ function normalizeAgents(snapshot) {
   return agents;
 }
 
+const NOISE_EVENT_KINDS = new Set(['worker-tick', 'worker-skip']);
+
+function eventTimeMs(event) {
+  return toDate(event?.at)?.getTime() ?? 0;
+}
+
+function deriveEventSeverity({ kind, message }) {
+  const normalizedKind = String(kind ?? '').toLowerCase();
+  const normalizedMessage = String(message ?? '').toLowerCase();
+
+  if (normalizedKind.includes('error') || normalizedMessage.includes('error') || normalizedMessage.includes('failed')) return 'error';
+  if (normalizedKind.includes('blocked') || normalizedMessage.includes('blocked') || normalizedKind.includes('degraded')) return 'warn';
+  return 'info';
+}
+
+function parseTaskMessage(message) {
+  const match = String(message ?? '').match(/^(assigned|completed|blocked|cancelled|reopened) task: (.+)$/i);
+  if (!match) return null;
+  return {
+    action: match[1].toLowerCase(),
+    subject: match[2].trim(),
+  };
+}
+
+function deriveEventTitle({ kind, message }) {
+  if (kind === 'task') {
+    const parsed = parseTaskMessage(message);
+    if (parsed) return `Task ${parsed.action}`;
+    return 'Task event';
+  }
+  if (kind === 'dispatch') return 'Task dispatch';
+  if (kind === 'worker-tick') return 'Worker tick';
+  if (kind === 'worker-skip') return 'Worker skip';
+  return kind ? `${kind} event` : 'Event';
+}
+
+function deriveEventSummary({ kind, message }) {
+  if (kind === 'task') {
+    const parsed = parseTaskMessage(message);
+    if (parsed) return parsed.subject;
+  }
+  return String(message ?? '').trim();
+}
+
+function normalizeEventRecord(event, { index } = {}) {
+  const kind = typeof event?.kind === 'string' ? event.kind : 'unknown';
+  const message = typeof event?.message === 'string' ? event.message : '';
+  const at = typeof event?.at === 'string' ? event.at : null;
+  let agentId = typeof event?.agentId === 'string'
+    ? event.agentId
+    : (typeof event?.agent_id === 'string' ? event.agent_id : null);
+
+  // For dispatch events, the actor is often the dispatcher; derive the target agent from message.
+  if (kind === 'dispatch' && typeof message === 'string') {
+    const match = message.match(/\bto\s+([a-z0-9_-]+)\s*$/i);
+    if (match) agentId = match[1];
+  }
+  const source = typeof event?.source === 'string' ? event.source : 'runtime';
+
+  const severity = typeof event?.severity === 'string'
+    ? event.severity
+    : deriveEventSeverity({ kind, message });
+
+  const title = typeof event?.title === 'string'
+    ? event.title
+    : deriveEventTitle({ kind, message });
+
+  const summary = typeof event?.summary === 'string'
+    ? event.summary
+    : deriveEventSummary({ kind, message });
+
+  return {
+    ...event,
+    at,
+    kind,
+    severity,
+    agentId,
+    // keep legacy field for compatibility
+    agent_id: typeof event?.agent_id === 'string' ? event.agent_id : agentId,
+    source,
+    title,
+    summary,
+    message,
+    _index: index,
+  };
+}
+
+function normalizeEvents(rawEvents) {
+  const items = Array.isArray(rawEvents) ? rawEvents : [];
+  const normalized = items.map((event, index) => normalizeEventRecord(event, { index }));
+  normalized.sort((a, b) => {
+    const delta = eventTimeMs(b) - eventTimeMs(a);
+    if (delta !== 0) return delta;
+    return (a._index ?? 0) - (b._index ?? 0);
+  });
+  return normalized;
+}
+
+function mergeNoiseEvents(events) {
+  const merged = [];
+
+  for (const event of events) {
+    const previous = merged.at(-1);
+    const isNoise = NOISE_EVENT_KINDS.has(event.kind);
+
+    if (
+      previous
+      && isNoise
+      && previous.kind === event.kind
+      && previous.agentId === event.agentId
+    ) {
+      previous.count = (previous.count ?? 1) + 1;
+      previous.atEnd = event.at ?? previous.atEnd ?? null;
+      previous.summary = previous.count > 1
+        ? `${previous.summary} (+${previous.count - 1} similar)`
+        : previous.summary;
+      continue;
+    }
+
+    merged.push({ ...event });
+  }
+
+  return merged;
+}
+
+function buildTimeline(events) {
+  // Input is expected sorted by at DESC.
+  const items = [];
+
+  for (const event of events) {
+    if (NOISE_EVENT_KINDS.has(event.kind)) continue;
+
+    if (event.kind === 'task') {
+      const parsed = parseTaskMessage(event.message);
+      if (!parsed) continue;
+      const severity = parsed.action === 'blocked' ? 'warn' : 'info';
+      items.push({
+        at: event.at,
+        kind: `task.${parsed.action}`,
+        severity,
+        agentId: event.agentId,
+        source: event.source,
+        title: `Task ${parsed.action}`,
+        summary: parsed.subject,
+        message: event.message,
+        extra: event.extra,
+        _index: event._index,
+      });
+      continue;
+    }
+
+    if (event.kind === 'dispatch') {
+      items.push({
+        at: event.at,
+        kind: 'dispatch',
+        severity: 'info',
+        agentId: event.agentId,
+        source: event.source,
+        title: 'Task dispatched',
+        summary: event.summary,
+        message: event.message,
+        extra: event.extra,
+        _index: event._index,
+      });
+    }
+  }
+
+  // Stable order: timeline is time-ascending (oldest first).
+  items.sort((a, b) => {
+    const delta = eventTimeMs(a) - eventTimeMs(b);
+    if (delta !== 0) return delta;
+    return (a._index ?? 0) - (b._index ?? 0);
+  });
+
+  return items;
+}
+
 export function createNotFound(agentId, meta) {
   return {
     error: {
@@ -262,11 +439,18 @@ export async function getDashboard() {
       degraded: entry.degraded,
     }));
 
+  const events = mergeNoiseEvents(normalizeEvents(snapshot.events)).slice(0, 200);
+  const timeline = buildTimeline(events).slice(-200);
+
   return {
     data: {
       agents,
       leaderboard,
+      // legacy
       recentEvents: snapshot.events.slice(-50),
+      // normalized
+      events,
+      timeline,
       sourceStatus: snapshot.sourceStatus,
     },
     meta: snapshot.meta,
@@ -293,10 +477,19 @@ export async function getAgentDetail(agentId) {
     .sort((a, b) => (toDate(b.updated_at)?.getTime() ?? 0) - (toDate(a.updated_at)?.getTime() ?? 0))
     .slice(0, 50);
 
-  const recentEvents = snapshot.events
+  // Legacy: keep raw events strictly filtered by agent_id.
+  const rawEvents = snapshot.events
     .filter((evt) => evt.agent_id === agentId)
-    .sort((a, b) => (toDate(b.at)?.getTime() ?? 0) - (toDate(a.at)?.getTime() ?? 0))
-    .slice(0, 50);
+    .sort((a, b) => (toDate(b.at)?.getTime() ?? 0) - (toDate(a.at)?.getTime() ?? 0));
+
+  const recentEvents = rawEvents.slice(0, 50);
+
+  // Normalized: filter by derived agentId (e.g. dispatch events targeted to this agent).
+  const normalizedEvents = normalizeEvents(snapshot.events)
+    .filter((evt) => evt.agentId === agentId);
+
+  const events = mergeNoiseEvents(normalizedEvents).slice(0, 200);
+  const timeline = buildTimeline(events).slice(-200);
 
   const markdownFiles = await listMarkdownFiles();
 
@@ -304,7 +497,11 @@ export async function getAgentDetail(agentId) {
     data: {
       ...summary,
       tasks,
+      // legacy
       recentEvents,
+      // normalized
+      events,
+      timeline,
       sourceStatus: snapshot.sourceStatus,
       markdownFiles: markdownFiles.data,
     },

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -49,6 +49,22 @@ test('GET /api/dashboard returns aggregated dashboard payload', async () => {
     assert.ok(payload.data.agents.some((agent) => agent.agentId === 'buding'));
     assert.equal(typeof payload.meta.collectedAt, 'string');
     assert.ok(payload.meta.freshness);
+
+    assert.ok(Array.isArray(payload.data.events));
+    assert.ok(Array.isArray(payload.data.timeline));
+
+    const first = payload.data.events[0];
+    for (const key of ['at', 'kind', 'severity', 'agentId', 'source', 'title', 'summary']) {
+      assert.ok(Object.hasOwn(first, key));
+    }
+
+    const tick = payload.data.events.find((evt) => evt.kind === 'worker-tick');
+    assert.ok(tick);
+    assert.equal(tick.count, 3);
+
+    // Timeline is stable and time-ascending.
+    assert.equal(payload.data.timeline[0].at, '2026-03-10T00:02:00Z');
+    assert.equal(payload.data.timeline.at(-1).at, '2026-03-10T00:04:00Z');
   });
 });
 
@@ -61,6 +77,13 @@ test('GET /api/agents/:id returns detail payload for known agent', async () => {
     assert.ok(Array.isArray(payload.data.tasks));
     assert.ok(Array.isArray(payload.data.recentEvents));
     assert.ok(Array.isArray(payload.data.markdownFiles));
+
+    assert.ok(Array.isArray(payload.data.events));
+    assert.ok(Array.isArray(payload.data.timeline));
+
+    const dispatch = payload.data.timeline.find((evt) => evt.kind === 'dispatch');
+    assert.ok(dispatch);
+    assert.equal(dispatch.agentId, 'buding');
   });
 });
 

--- a/test/fixtures/runtime/events.json
+++ b/test/fixtures/runtime/events.json
@@ -1,12 +1,60 @@
 [
   {
-    "at": "2026-03-10T00:03:00Z",
-    "kind": "task",
+    "at": "2026-03-10T00:05:03Z",
+    "kind": "worker-tick",
     "agent_id": "buding",
-    "message": "assigned task: fixture",
+    "message": "started worker tick pid=111",
+    "extra": { "pid": 111 }
+  },
+  {
+    "at": "2026-03-10T00:05:02Z",
+    "kind": "worker-tick",
+    "agent_id": "buding",
+    "message": "started worker tick pid=112",
+    "extra": { "pid": 112 }
+  },
+  {
+    "at": "2026-03-10T00:05:01Z",
+    "kind": "worker-tick",
+    "agent_id": "buding",
+    "message": "started worker tick pid=113",
+    "extra": { "pid": 113 }
+  },
+  {
+    "at": "2026-03-10T00:04:00Z",
+    "kind": "dispatch",
+    "agent_id": "ollie",
+    "message": "ollie dispatched '[P4] fixture task' to buding",
     "extra": {
       "task_id": "buding-2",
       "issue_url": "https://github.com/gstranded/openclaw-monitor/issues/32"
     }
+  },
+  {
+    "at": "2026-03-10T00:03:00Z",
+    "kind": "task",
+    "agent_id": "buding",
+    "message": "assigned task: [P4] fixture task",
+    "extra": {
+      "task_id": "buding-2",
+      "issue_url": "https://github.com/gstranded/openclaw-monitor/issues/32"
+    }
+  },
+  {
+    "at": "2026-03-10T00:03:30Z",
+    "kind": "task",
+    "agent_id": "buding",
+    "message": "blocked task: [P4] fixture task",
+    "extra": {
+      "task_id": "buding-2",
+      "reason": "fixture"
+    }
+  },
+  {
+    "at": "2026-03-10T00:02:00Z",
+    "kind": "task",
+    "agent_id": "naicha",
+    "message": "assigned task: other agent",
+    "extra": { "task_id": "naicha-1" }
   }
 ]


### PR DESCRIPTION
Implements event normalization + de-noised timeline semantics for #54.

Backend changes:
- Adds `data.events` + `data.timeline` to `/api/dashboard` and `/api/agents/:id` (keeps legacy `recentEvents` for back-compat)
- Normalizes event fields: kind/severity/agentId/source/title/summary/at
- Merges obvious noise (worker-tick/worker-skip) with `count` + `atEnd`
- Timeline is key status changes (task.* + dispatch) and ordered by time ascending

Docs:
- docs/ARCHITECTURE.md: event schema + ordering + merge semantics

Checks:
- npm run check
- npm test

Closes #54.