### PR TITLE
feat: staff/activity digest summary on /api/dashboard (#61)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,7 +74,35 @@ Backend 从 `events.json` 读取 **raw events**，并在聚合接口中输出两
 - `count`：合并数量
 - `atEnd`：合并覆盖的最早时间（可选）
 
-## 5. Markdown 管理的安全边界
+## 5. Staff / Activity digest
+
+为了避免把 task 作为 UI 的“原始 payload”完整搬运，Backend 在 `/api/dashboard` 输出两类更面向运营的摘要：
+
+- `staff[]`: 每个 agent 的“正在干嘛/下一项/证据/活跃时间”视图
+- `activityDigest[]`: `staff[]` 的精简版（便于 overview/hero 区展示）
+
+### 5.1 Staff schema (MVP)
+
+每个 `staff[]` 元素至少包含：
+
+- `agentId`
+- `status`: `working` | `standby` | `idle`
+- `currentActivity`: string | null（默认不包含完整 task 原文）
+- `nextActivity`: string | null
+- `lastEvidenceLink`: string | null
+- `lastActiveAt`: ISO string | null
+
+可选 detail 字段用于 UI 展开：`currentActivityDetail` / `nextActivityDetail`。
+
+### 5.2 Status semantics
+
+- `working`: 存在可验证的“活跃证据”（例如 sessions 记录或近期事件）
+- `standby`: 有 backlog（todo/blocked）但无近期活跃证据
+- `idle`: 无 backlog 且无近期活跃证据
+
+缺失 sessions/events 时：通过 `meta.partial` + `meta.degradeReasons` 对 UI 明确降级。
+
+## 6. Markdown 管理的安全边界
 
 写操作（保存）必须满足：
 
@@ -86,7 +114,7 @@ Backend 从 `events.json` 读取 **raw events**，并在聚合接口中输出两
 
 策略配置：`config/markdown-boundaries.json`
 
-## 6. Frontend
+## 7. Frontend
 
 - Vite + React，组件在 `web/src/components/`
 - 页面：
@@ -95,7 +123,7 @@ Backend 从 `events.json` 读取 **raw events**，并在聚合接口中输出两
   - `MarkdownListPage.tsx`
   - `MarkdownEditorPage.tsx`
 
-## 7. Non-goals
+## 8. Non-goals
 
 - 本项目当前不提供：认证/鉴权、多租户、写操作运维闭环。
 - Phase 2 / 3 目标是把“观察面与受控写入”做好，后续再扩展。

--- a/src/data.js
+++ b/src/data.js
@@ -143,13 +143,14 @@ function buildSourceStatus(collectedAtMs, sources) {
 async function loadSnapshot() {
   const collectedAtMs = Date.now();
   const runtimeRoot = await resolveRuntimeRoot();
-  const [scores, tasks, events] = await Promise.all([
+  const [scores, tasks, events, sessions] = await Promise.all([
     loadJson(runtimeRoot, 'scores.json'),
     loadJson(runtimeRoot, 'tasks.json'),
     loadJson(runtimeRoot, 'events.json'),
+    loadJson(runtimeRoot, 'sessions.json'),
   ]);
 
-  const sources = { scores, tasks, events };
+  const sources = { scores, tasks, events, sessions };
   const meta = buildMeta(collectedAtMs, sources);
   const sourceStatus = buildSourceStatus(collectedAtMs, sources);
 
@@ -160,6 +161,7 @@ async function loadSnapshot() {
     scores: scores.ok ? scores.data : {},
     tasks: tasks.ok ? tasks.data : [],
     events: events.ok ? events.data : [],
+    sessions: sessions.ok ? sessions.data : [],
     meta,
     sourceStatus,
   };
@@ -207,6 +209,9 @@ function normalizeAgents(snapshot) {
     ...Object.keys(scoreEntries),
     ...snapshot.tasks.map((t) => t.agent_id).filter(Boolean),
     ...snapshot.events.map((e) => e.agent_id).filter(Boolean),
+    ...(Array.isArray(snapshot.sessions)
+      ? snapshot.sessions.map((s) => s.agent_id ?? s.agentId).filter(Boolean)
+      : []),
   ]);
 
   const agents = Array.from(agentIds).sort().map((agentId) => {
@@ -412,6 +417,174 @@ function buildTimeline(events) {
   return items;
 }
 
+function getNowMs(snapshot) {
+  if (process.env.OPENCLAW_NOW_ISO) {
+    const parsed = Date.parse(process.env.OPENCLAW_NOW_ISO);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return snapshot?.collectedAtMs ?? Date.now();
+}
+
+function collapseWhitespace(value) {
+  return String(value ?? '').replaceAll(/\s+/g, ' ').trim();
+}
+
+function summarizeTaskTitle(title, maxLen = 48) {
+  const normalized = collapseWhitespace(title);
+  const stripped = normalized.replace(/^\[[^\]]+\]\s*/, '');
+  if (stripped.length <= maxLen) return stripped;
+  return `${stripped.slice(0, maxLen - 1)}…`;
+}
+
+function classifyBacklogTasks(tasksForAgent) {
+  const backlogStatuses = new Set(['todo', 'blocked', 'in_progress']);
+  const backlog = tasksForAgent.filter((task) => backlogStatuses.has(task.status));
+  const sorted = [...backlog].sort((a, b) => {
+    const aAt = toDate(a.updated_at || a.created_at)?.getTime() ?? 0;
+    const bAt = toDate(b.updated_at || b.created_at)?.getTime() ?? 0;
+    return bAt - aAt;
+  });
+  return {
+    backlog: sorted,
+    current: sorted[0] ?? null,
+    next: sorted[1] ?? null,
+  };
+}
+
+function extractEvidenceLinkFromEvent(event) {
+  const extra = event?.extra && typeof event.extra === 'object' ? event.extra : {};
+  for (const key of ['issue_url', 'pr_url', 'html_url', 'url', 'link']) {
+    if (typeof extra[key] === 'string' && extra[key].startsWith('http')) return extra[key];
+  }
+  const messageUrl = String(event?.message ?? '').match(/https?:\/\/\S+/);
+  return messageUrl ? messageUrl[0] : null;
+}
+
+function normalizeSessions(rawSessions) {
+  const items = Array.isArray(rawSessions) ? rawSessions : [];
+  const activeStates = new Set(['active', 'running', 'busy']);
+
+  return items.map((session, index) => {
+    const agentId = typeof session?.agentId === 'string'
+      ? session.agentId
+      : (typeof session?.agent_id === 'string' ? session.agent_id : null);
+    const status = typeof session?.status === 'string'
+      ? session.status
+      : (typeof session?.state === 'string' ? session.state : 'unknown');
+
+    const lastActiveAt = session?.last_active_at ?? session?.lastActiveAt ?? session?.updated_at ?? session?.updatedAt ?? null;
+    const lastActiveAtMs = toDate(lastActiveAt)?.getTime() ?? null;
+
+    const link = typeof session?.link === 'string'
+      ? session.link
+      : (typeof session?.url === 'string' ? session.url : null);
+
+    return {
+      agentId,
+      status,
+      active: activeStates.has(String(status).toLowerCase()),
+      lastActiveAt: typeof lastActiveAt === 'string' ? lastActiveAt : null,
+      lastActiveAtMs,
+      link: typeof link === 'string' && link.startsWith('http') ? link : null,
+      _index: index,
+    };
+  }).filter((session) => Boolean(session.agentId));
+}
+
+function buildStaffView({ snapshot, agents, normalizedEvents }) {
+  const nowMs = getNowMs(snapshot);
+  const workingWindowMs = Number.parseInt(process.env.OPENCLAW_WORKING_WINDOW_MS ?? '600000', 10);
+
+  const sessions = normalizeSessions(snapshot.sessions);
+
+  const sessionsByAgent = new Map();
+  for (const session of sessions) {
+    const list = sessionsByAgent.get(session.agentId) ?? [];
+    list.push(session);
+    sessionsByAgent.set(session.agentId, list);
+  }
+
+  const eventsByAgent = new Map();
+  for (const event of normalizedEvents) {
+    const list = eventsByAgent.get(event.agentId) ?? [];
+    list.push(event);
+    eventsByAgent.set(event.agentId, list);
+  }
+
+  const staff = agents.map((agent) => {
+    const tasksForAgent = snapshot.tasks.filter((task) => task.agent_id === agent.agentId);
+    const backlog = classifyBacklogTasks(tasksForAgent);
+
+    const agentSessions = sessionsByAgent.get(agent.agentId) ?? [];
+    const agentEvents = eventsByAgent.get(agent.agentId) ?? [];
+
+    agentSessions.sort((a, b) => (b.lastActiveAtMs ?? 0) - (a.lastActiveAtMs ?? 0) || (a._index ?? 0) - (b._index ?? 0));
+    agentEvents.sort((a, b) => eventTimeMs(b) - eventTimeMs(a) || (a._index ?? 0) - (b._index ?? 0));
+
+    const sessionEvidence = agentSessions.find((session) => session.lastActiveAtMs != null) ?? null;
+    const eventEvidence = agentEvents.find((evt) => evt.at) ?? null;
+
+    const sessionAtMs = sessionEvidence?.lastActiveAtMs ?? null;
+    const eventAtMs = eventEvidence ? eventTimeMs(eventEvidence) : null;
+
+    const lastActiveAtMs = Math.max(sessionAtMs ?? 0, eventAtMs ?? 0) || null;
+    const lastActiveAt = lastActiveAtMs ? new Date(lastActiveAtMs).toISOString() : null;
+
+    const hasRecentEvidence = lastActiveAtMs != null && (nowMs - lastActiveAtMs) <= workingWindowMs;
+    const hasLiveSession = agentSessions.some((session) => session.active && session.lastActiveAtMs != null && (nowMs - session.lastActiveAtMs) <= workingWindowMs);
+
+    const hasBacklog = backlog.backlog.length > 0;
+
+    const status = hasLiveSession || hasRecentEvidence
+      ? 'working'
+      : (hasBacklog ? 'standby' : 'idle');
+
+    const currentTask = backlog.current;
+    const nextTask = backlog.next;
+
+    const currentSummary = currentTask ? summarizeTaskTitle(currentTask.title) : null;
+    const nextSummary = nextTask ? summarizeTaskTitle(nextTask.title) : null;
+
+    const currentActivity = currentSummary
+      ? (status === 'working' ? `Working: ${currentSummary}` : `Backlog: ${currentSummary}`)
+      : (status === 'working' ? 'Working' : null);
+
+    const nextActivity = nextSummary ? `Next: ${nextSummary}` : null;
+
+    const evidenceLink = (
+      agentSessions.map((s) => s.link).find(Boolean)
+      ?? agentEvents.map((evt) => extractEvidenceLinkFromEvent(evt)).find(Boolean)
+      ?? (typeof currentTask?.issue_url === 'string' && currentTask.issue_url.startsWith('http') ? currentTask.issue_url : null)
+      ?? null
+    );
+
+    return {
+      agentId: agent.agentId,
+      displayName: agent.displayName,
+      emoji: agent.emoji,
+      role: agent.role,
+      status,
+      currentActivity,
+      currentActivityDetail: currentTask ? { taskId: currentTask.id ?? null, issueUrl: currentTask.issue_url ?? null } : null,
+      nextActivity,
+      nextActivityDetail: nextTask ? { taskId: nextTask.id ?? null, issueUrl: nextTask.issue_url ?? null } : null,
+      lastEvidenceLink: evidenceLink,
+      lastActiveAt,
+    };
+  });
+
+  const activityDigest = staff.map((entry) => ({
+    agentId: entry.agentId,
+    status: entry.status,
+    currentActivity: entry.currentActivity,
+    nextActivity: entry.nextActivity,
+    lastEvidenceLink: entry.lastEvidenceLink,
+    lastActiveAt: entry.lastActiveAt,
+  }));
+
+  return { staff, activityDigest };
+}
+
 export function createNotFound(agentId, meta) {
   return {
     error: {
@@ -441,11 +614,14 @@ export async function getDashboard() {
 
   const events = mergeNoiseEvents(normalizeEvents(snapshot.events)).slice(0, 200);
   const timeline = buildTimeline(events).slice(-200);
+  const staffView = buildStaffView({ snapshot, agents, normalizedEvents: events });
 
   return {
     data: {
       agents,
       leaderboard,
+      staff: staffView.staff,
+      activityDigest: staffView.activityDigest,
       // legacy
       recentEvents: snapshot.events.slice(-50),
       // normalized

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -7,6 +7,7 @@ import os from 'node:os';
 
 process.env.NODE_ENV = 'test';
 process.env.OPENCLAW_RUNTIME_DIR = path.resolve(process.cwd(), 'test/fixtures/runtime');
+process.env.OPENCLAW_NOW_ISO = '2026-03-10T00:06:00Z';
 
 const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-monitor-data-'));
 process.env.OPENCLAW_DATA_DIR = dataDir;
@@ -65,6 +66,22 @@ test('GET /api/dashboard returns aggregated dashboard payload', async () => {
     // Timeline is stable and time-ascending.
     assert.equal(payload.data.timeline[0].at, '2026-03-10T00:02:00Z');
     assert.equal(payload.data.timeline.at(-1).at, '2026-03-10T00:04:00Z');
+
+    assert.ok(Array.isArray(payload.data.staff));
+    assert.ok(Array.isArray(payload.data.activityDigest));
+
+    const staffBuding = payload.data.staff.find((entry) => entry.agentId === 'buding');
+    assert.ok(staffBuding);
+    for (const key of ['status', 'currentActivity', 'nextActivity', 'lastEvidenceLink', 'lastActiveAt']) {
+      assert.ok(Object.hasOwn(staffBuding, key));
+    }
+    assert.equal(staffBuding.status, 'working');
+    assert.match(staffBuding.currentActivity, /^Working:/);
+    assert.match(staffBuding.lastEvidenceLink, /^https?:\/\//);
+
+    const digestBuding = payload.data.activityDigest.find((entry) => entry.agentId === 'buding');
+    assert.ok(digestBuding);
+    assert.equal(digestBuding.status, 'working');
   });
 });
 

--- a/test/fixtures/runtime/sessions.json
+++ b/test/fixtures/runtime/sessions.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "sess-1",
+    "agent_id": "buding",
+    "status": "active",
+    "last_active_at": "2026-03-10T00:05:30Z",
+    "link": "https://github.com/gstranded/openclaw-monitor/issues/32"
+  }
+]


### PR DESCRIPTION
Implements staff/activity summary layer requested in #61 (avoid full task payload in UI).

Backend:
- Extends GET /api/dashboard with `staff[]` + `activityDigest[]`
- Status semantics: working vs standby vs idle (working requires evidence within window)
- Adds optional `sessions.json` as a data source for evidence; when missing, meta.degradeReasons includes sessions_unavailable

Docs:
- docs/ARCHITECTURE.md: Staff/Activity digest schema + semantics

Checks:
- npm run check
- npm test

Closes #61.