### PR TITLE
[P5-ui] Dashboard clarity: overview hero + staff snapshot + digest events

### DIFF
--- a/web/src/components/ActionableDigest.tsx
+++ b/web/src/components/ActionableDigest.tsx
@@ -1,0 +1,48 @@
+import type { EventItem } from '../lib/dashboardTypes'
+import Linkify from './Linkify'
+
+function fmtRelative(ts: string) {
+  const d = new Date(ts)
+  const ms = d.getTime()
+  if (!Number.isFinite(ms)) return ts
+  const diff = Date.now() - ms
+  const m = Math.round(diff / 60000)
+  if (m < 1) return 'just now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.round(m / 60)
+  if (h < 48) return `${h}h ago`
+  const day = Math.round(h / 24)
+  return `${day}d ago`
+}
+
+export default function ActionableDigest({ events }: { events: EventItem[] }) {
+  if (!events.length) return <div className="empty">No events.</div>
+
+  const actionable = events.filter((e) => (e.severity || 'info') !== 'info')
+  const picked = (actionable.length ? actionable : events).slice(0, 6)
+
+  return (
+    <div className="digest">
+      <ul className="digestList">
+        {picked.map((e) => (
+          <li key={e.id} className={`digestItem sev-${e.severity || 'info'}`}>
+            <div className="digestTop">
+              <span className="digestTitle">{e.title || e.type || 'event'}</span>
+              <span className="muted">{fmtRelative(e.ts)}</span>
+            </div>
+            <div className="digestMsg">
+              <Linkify text={e.message} />
+            </div>
+            <div className="digestMeta">
+              {e.severity ? <span className={`chip sev-${e.severity}`}>{e.severity}</span> : null}
+              {e.agentId ? <span className="chip">{e.agentId}</span> : null}
+              {e.type ? <span className="chip">{e.type}</span> : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="digestHint muted">Showing {picked.length} most recent {actionable.length ? 'warn/error' : ''} items.</div>
+    </div>
+  )
+}

--- a/web/src/components/EventStream.tsx
+++ b/web/src/components/EventStream.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import type { EventItem } from '../lib/dashboardTypes'
+import Linkify from './Linkify'
 
 function fmt(ts: string) {
   const d = new Date(ts)
@@ -168,8 +169,15 @@ export default function EventStream({ items, loading }: { items: EventItem[]; lo
 
                     <div className="eventText">
                       <div className="eventTitle">{it.title || it.type || 'event'}</div>
-                      <div className="eventSummary">{it.message}</div>
-                      {it.detail ? <pre className="eventDetail">{it.detail}</pre> : null}
+                      <div className="eventSummary">
+                        <Linkify text={it.message} />
+                      </div>
+                      {it.detail ? (
+                        <details className="eventDetailToggle">
+                          <summary className="eventDetailSummary">raw detail</summary>
+                          <pre className="eventDetail">{it.detail}</pre>
+                        </details>
+                      ) : null}
                     </div>
                   </div>
                 </li>

--- a/web/src/components/Linkify.tsx
+++ b/web/src/components/Linkify.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+
+// Very small URL linkifier for logs/event summaries.
+// - only http/https
+// - intentionally conservative (no markdown parsing)
+const URL_RE = /(https?:\/\/[^\s)\]]+)/g
+
+export default function Linkify({ text }: { text: string }): ReactNode {
+  const parts: ReactNode[] = []
+  let last = 0
+
+  for (const m of text.matchAll(URL_RE)) {
+    const start = m.index ?? 0
+    const url = m[0]
+    if (start > last) parts.push(text.slice(last, start))
+    parts.push(
+      <a key={`${start}-${url}`} href={url} target="_blank" rel="noreferrer">
+        {url}
+      </a>
+    )
+    last = start + url.length
+  }
+
+  if (last < text.length) parts.push(text.slice(last))
+  return <>{parts}</>
+}

--- a/web/src/components/OverviewHero.tsx
+++ b/web/src/components/OverviewHero.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react'
+import type { AgentSummary, DashboardHealth, DashboardMeta, EventItem } from '../lib/dashboardTypes'
+import StatusBadge from './StatusBadge'
+import ThemeToggle from './ThemeToggle'
+import StaffSnapshot from './StaffSnapshot'
+import ActionableDigest from './ActionableDigest'
+
+function fmtTime(ts?: string) {
+  if (!ts) return '—'
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ts
+  return d.toLocaleString()
+}
+
+function sourceSummary(meta?: DashboardMeta) {
+  const sources = meta?.sources || {}
+  const keys = Object.keys(sources)
+  let worstMs = 0
+  let bad = 0
+  for (const k of keys) {
+    const s = sources[k]
+    if (typeof s?.freshnessMs === 'number') worstMs = Math.max(worstMs, s.freshnessMs)
+    if (s?.health && s.health !== 'ok') bad++
+  }
+  return { total: keys.length, worstMs, bad }
+}
+
+function Pill({ children }: { children: ReactNode }) {
+  return <span className="pill">{children}</span>
+}
+
+export default function OverviewHero({
+  apiBase,
+  meta,
+  health,
+  updatedAt,
+  agents,
+  events,
+  loading,
+  polling,
+  onRefresh
+}: {
+  apiBase: string
+  meta?: DashboardMeta
+  health: DashboardHealth
+  updatedAt?: string | null
+  agents: AgentSummary[]
+  events: EventItem[]
+  loading?: boolean
+  polling?: boolean
+  onRefresh: () => void
+}) {
+  const s = sourceSummary(meta)
+  const online = agents.filter((a) => a.status === 'online').length
+  const busy = agents.filter((a) => a.status === 'busy').length
+
+  return (
+    <section className="heroCard">
+      <div className="heroTop">
+        <div>
+          <div className="heroKicker">openclaw-monitor</div>
+          <div className="heroTitle">Dashboard overview</div>
+          <div className="heroSub muted">Health · Staff · Actionable digest</div>
+        </div>
+
+        <div className="heroActions">
+          <button className="btn primary" onClick={onRefresh} disabled={!!loading}>
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+          <ThemeToggle />
+        </div>
+      </div>
+
+      <div className="heroMeta">
+        <Pill>
+          <span className="muted">api</span> <code className="code">{apiBase}</code>
+        </Pill>
+        <Pill>
+          <span className="muted">updated</span> {fmtTime(updatedAt || meta?.generatedAt)}
+        </Pill>
+        <Pill>
+          <StatusBadge health={health} />
+          {polling ? <span className="muted">auto-updating…</span> : null}
+        </Pill>
+        <Pill>
+          <span className="muted">staff</span> {online} active / {busy} blocked
+        </Pill>
+        <Pill>
+          <span className="muted">sources</span> {s.bad}/{s.total} degraded
+          {s.worstMs ? <span className="muted"> · worst lag {Math.round(s.worstMs / 1000)}s</span> : null}
+        </Pill>
+      </div>
+
+      <div className="heroGrid">
+        <div className="heroPanel">
+          <div className="heroPanelTitle">System health</div>
+          <div className="heroPanelBody">
+            <div className="healthRow">
+              <StatusBadge health={health} />
+              <div className="muted">{meta?.health ? `health=${meta.health}` : 'health unknown'}</div>
+            </div>
+            <div className="healthHint muted">
+              Worst lag is computed from source freshness; full details below in “Sources”.
+            </div>
+          </div>
+        </div>
+
+        <div className="heroPanel">
+          <div className="heroPanelTitle">Staff snapshot</div>
+          <div className="heroPanelBody">
+            <StaffSnapshot agents={agents} />
+          </div>
+        </div>
+
+        <div className="heroPanel">
+          <div className="heroPanelTitle">Needs attention</div>
+          <div className="heroPanelBody">
+            <ActionableDigest events={events} />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/StaffSnapshot.tsx
+++ b/web/src/components/StaffSnapshot.tsx
@@ -1,0 +1,75 @@
+import type { AgentSummary } from '../lib/dashboardTypes'
+
+function statusLabel(s?: AgentSummary['status']) {
+  if (s === 'online') return 'active'
+  if (s === 'busy') return 'blocked'
+  if (s === 'idle') return 'idle'
+  if (s === 'offline') return 'offline'
+  return 'unknown'
+}
+
+function statusTone(s?: AgentSummary['status']) {
+  if (s === 'online') return 'ok'
+  if (s === 'busy') return 'warn'
+  if (s === 'offline') return 'bad'
+  return 'muted'
+}
+
+export default function StaffSnapshot({ agents }: { agents: AgentSummary[] }) {
+  if (!agents.length) return <div className="empty">No agents.</div>
+
+  const online = agents.filter((a) => a.status === 'online').length
+  const busy = agents.filter((a) => a.status === 'busy').length
+  const offline = agents.filter((a) => a.status === 'offline').length
+
+  const sorted = [...agents].sort((a, b) => {
+    const prio = (s?: AgentSummary['status']) =>
+      s === 'busy' ? 0 : s === 'online' ? 1 : s === 'idle' ? 2 : s === 'offline' ? 3 : 4
+    const dp = prio(a.status) - prio(b.status)
+    if (dp !== 0) return dp
+    const at = a.currentTask ? 0 : 1
+    const bt = b.currentTask ? 0 : 1
+    if (at !== bt) return at - bt
+    return (a.name || a.id).localeCompare(b.name || b.id)
+  })
+
+  const top = sorted.slice(0, 6)
+
+  return (
+    <div className="staff">
+      <div className="staffCounts">
+        <span className="pill">
+          <span className="muted">active</span> {online}
+        </span>
+        <span className="pill">
+          <span className="muted">blocked</span> {busy}
+        </span>
+        <span className="pill">
+          <span className="muted">offline</span> {offline}
+        </span>
+      </div>
+
+      <ul className="staffList">
+        {top.map((a) => (
+          <li key={a.id} className="staffRow">
+            <a className="staffLink" href={`/agents/${encodeURIComponent(a.id)}`}>
+              <span className="staffAvatar" aria-hidden>
+                {a.emoji || '•'}
+              </span>
+              <span className="staffMain">
+                <span className="staffName">{a.name || a.id}</span>
+                <span className="staffRole">{a.role || '—'}</span>
+                <span className={`staffStatus tone-${statusTone(a.status)}`}>{statusLabel(a.status)}</span>
+              </span>
+              <span className="staffTask" title={a.currentTask || ''}>
+                {a.currentTask || '—'}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      <div className="staffHint muted">Click a name to open agent detail.</div>
+    </div>
+  )
+}

--- a/web/src/lib/dashboardApi.ts
+++ b/web/src/lib/dashboardApi.ts
@@ -36,10 +36,11 @@ type AggSourceStatus = {
 type AggAgent = {
   agentId: string
   displayName?: string
+  emoji?: string
   role?: string
   status?: string
   lastActivityAt?: string | null
-  activeTask?: { title?: string } | null
+  activeTask?: { title?: string; issueUrl?: string } | null
   score?: number
 }
 
@@ -66,7 +67,12 @@ type AggDashboardEnvelope = {
   data?: {
     agents?: AggAgent[]
     leaderboard?: AggLeaderboardEntry[]
+    /** legacy: raw recent events */
     recentEvents?: AggEvent[]
+    /** preferred: normalized events with title/summary/severity */
+    events?: AggEvent[]
+    /** optional backend-filtered milestones */
+    timeline?: AggEvent[]
     sourceStatus?: AggSourceStatus[]
   }
   meta?: AggMeta
@@ -114,13 +120,19 @@ function sourceHealth(status: AggSourceStatus['status']): DashboardHealth {
 function normalizeAggEnvelope(envelope: AggDashboardEnvelope): DashboardResponse {
   const agentsRaw = envelope.data?.agents || []
   const leaderboardRaw = envelope.data?.leaderboard || []
-  const eventsRaw = envelope.data?.recentEvents || []
+
+  // Newer backend prefers `data.events` / `data.timeline` (already normalized).
+  // Keep `recentEvents` as fallback for older deployments.
+  const eventsRaw = envelope.data?.events || envelope.data?.recentEvents || []
+  const timelineRaw = envelope.data?.timeline || []
+
   const sourceStatus = envelope.data?.sourceStatus || []
   const meta = envelope.meta
 
   const agents: DashboardResponse['agents'] = agentsRaw.map((a) => ({
     id: a.agentId,
     name: a.displayName || a.agentId,
+    emoji: a.emoji,
     role: a.role,
     status: mapAgentStatus(a.status),
     lastSeenAt: a.lastActivityAt || undefined,
@@ -195,21 +207,35 @@ function normalizeAggEnvelope(envelope: AggDashboardEnvelope): DashboardResponse
     return bMs - aMs
   })
 
-  // Timeline should be "milestones" (state changes), not a firehose
-  const timeline: TimelineItem[] = normalizedEvents
-    .filter((ev) => isMilestone(ev.type, `${ev.title || ''} ${ev.message || ''}`))
-    .slice(-80)
-    .map((ev) => ({
-      id: ev.id,
-      ts: ev.ts,
-      title: ev.title || ev.type || 'event',
-      detail: ev.message,
-      severity: ev.severity,
-      meta: {
-        agentId: ev.agentId,
-        kind: ev.type
-      }
-    }))
+  const timeline: TimelineItem[] = timelineRaw.length
+    ? timelineRaw.slice(0, 120).map((ev, idx) => {
+        const agentId = ev.agentId || ev.agent_id
+        const kind = ev.kind
+        const message = ev.summary || ev.message || ev.title || ev.kind || 'event'
+        return {
+          id: ev.id || `${ev.at || 'na'}-${idx}`,
+          ts: ev.at || new Date().toISOString(),
+          title: ev.title || (kind ? humanizeKind(kind) : 'event'),
+          detail: message,
+          severity: pickSeverity(ev.severity, kind, message),
+          meta: { agentId, kind }
+        }
+      })
+    : // Fallback: infer milestones from the event stream.
+      normalizedEvents
+        .filter((ev) => isMilestone(ev.type, `${ev.title || ''} ${ev.message || ''}`))
+        .slice(-80)
+        .map((ev) => ({
+          id: ev.id,
+          ts: ev.ts,
+          title: ev.title || ev.type || 'event',
+          detail: ev.message,
+          severity: ev.severity,
+          meta: {
+            agentId: ev.agentId,
+            kind: ev.type
+          }
+        }))
 
   const sources: NonNullable<DashboardResponse['meta']>['sources'] = {}
 

--- a/web/src/lib/dashboardTypes.ts
+++ b/web/src/lib/dashboardTypes.ts
@@ -19,6 +19,7 @@ export interface DashboardMeta {
 export interface AgentSummary {
   id: string
   name: string
+  emoji?: string
   role?: string
   status?: AgentStatus
   lastSeenAt?: string

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -2,25 +2,17 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import AgentCardsRow from '../components/AgentCardsRow'
 import EventStream from '../components/EventStream'
 import Leaderboard from '../components/Leaderboard'
+import OverviewHero from '../components/OverviewHero'
 import SectionCard from '../components/SectionCard'
-import StatusBadge from '../components/StatusBadge'
-import ThemeToggle from '../components/ThemeToggle'
 import Timeline from '../components/Timeline'
 import type { DashboardHealth, DashboardResponse } from '../lib/dashboardTypes'
-import { HttpError } from '../lib/fetchJson'
 import { API_BASE, DASHBOARD_POLL_MS } from '../lib/config'
 import { loadDashboardSnapshot } from '../lib/dashboardApi'
+import { HttpError } from '../lib/fetchJson'
 
 function safeHealth(h?: string): DashboardHealth {
   if (h === 'ok' || h === 'partial' || h === 'degraded' || h === 'error') return h
   return 'unknown'
-}
-
-function fmtTime(ts?: string) {
-  if (!ts) return '—'
-  const d = new Date(ts)
-  if (Number.isNaN(d.getTime())) return ts
-  return d.toLocaleString()
 }
 
 export default function DashboardPage() {
@@ -33,7 +25,6 @@ export default function DashboardPage() {
   const abortRef = useRef<AbortController | null>(null)
 
   const health = safeHealth(data?.meta?.health)
-
   const apiBaseLabel = useMemo(() => API_BASE, [])
 
   async function loadOnce({ silent }: { silent: boolean }) {
@@ -88,18 +79,19 @@ export default function DashboardPage() {
   const timeline = data?.timeline ?? []
   const events = data?.events ?? []
 
-  const busy = loading || polling
-
   return (
     <div className="page">
       <header className="topbar">
         <div className="brand">
           <div className="title">openclaw-monitor</div>
-          <div className="subtitle">Dashboard</div>
+          <div className="subtitle">Operational dashboard</div>
           <nav className="nav">
-            <a className="navLink" href="/">🏠 Dashboard</a>
-            <a className="navLink" href="/staff">🧑‍💼 Staff</a>
-            <a className="navLink" href="/markdown">📝 Markdown</a>
+            <a className="navLink" href="/">
+              🏠 Dashboard
+            </a>
+            <a className="navLink" href="/markdown">
+              📝 Markdown
+            </a>
           </nav>
         </div>
 
@@ -108,19 +100,6 @@ export default function DashboardPage() {
             <span className="muted">api</span>
             <code className="code">{apiBaseLabel}</code>
           </div>
-          <div className="metaLine">
-            <span className="muted">updated</span>
-            <span>{fmtTime(lastUpdatedAt || data?.meta?.generatedAt)}</span>
-            <span className="sep">·</span>
-            <StatusBadge health={health} />
-            {polling ? <span className="muted">auto-updating…</span> : null}
-          </div>
-          <div className="btnRow">
-            <button className="btn primary" onClick={() => void loadOnce({ silent: false })} disabled={loading}>
-              {loading ? 'Loading…' : 'Refresh'}
-            </button>
-            <ThemeToggle />
-          </div>
         </div>
       </header>
 
@@ -128,58 +107,63 @@ export default function DashboardPage() {
         <div className="banner error">
           <div className="bannerTitle">Failed to load dashboard</div>
           <pre className="bannerBody">{error}</pre>
-          <div className="bannerHint">
-            We still tried a real API call. When backend is not ready yet, this is expected.
-          </div>
+          <div className="bannerHint">We still tried a real API call. When backend is not ready yet, this is expected.</div>
         </div>
       ) : null}
 
       {health === 'partial' || health === 'degraded' ? (
         <div className={`banner ${health === 'partial' ? 'partial' : 'degraded'}`}>
           <div className="bannerTitle">{health.toUpperCase()} data</div>
-          <div className="bannerBody">
-            Some sources are stale or unavailable. UI should remain usable and clearly indicate limitations.
-          </div>
+          <div className="bannerBody">Some sources are stale or unavailable. UI stays usable and indicates limitations.</div>
         </div>
       ) : null}
 
       <main className="grid">
-        <div className="gridTop">
-          <SectionCard
-            title="Agents"
-            right={
-              <span className="muted">
-                {agents.length} total · <a href="/staff">staff view</a>
-              </span>
-            }
-          >
-            <AgentCardsRow agents={agents} />
-          </SectionCard>
-        </div>
+        <OverviewHero
+          apiBase={apiBaseLabel}
+          meta={data?.meta}
+          health={health}
+          updatedAt={lastUpdatedAt || data?.meta?.generatedAt}
+          agents={agents}
+          events={events}
+          loading={loading}
+          polling={polling}
+          onRefresh={() => void loadOnce({ silent: false })}
+        />
+
+        <SectionCard title="Agents" right={<span className="muted">{agents.length} total</span>}>
+          <AgentCardsRow agents={agents} />
+        </SectionCard>
 
         <div className="gridCols">
           <div className="col">
             <SectionCard title="Timeline" right={<span className="muted">milestones</span>}>
-              <Timeline items={timeline} loading={busy} />
+              <Timeline items={timeline} loading={loading || polling} />
             </SectionCard>
           </div>
 
           <div className="col">
-            <SectionCard title="Leaderboard" right={<span className="muted">Points</span>}>
+            <SectionCard title="Leaderboard" right={<span className="muted">points</span>}>
               <Leaderboard rows={leaderboard} />
             </SectionCard>
           </div>
 
           <div className="col">
-            <SectionCard title="Events" right={<span className="muted">filters + search</span>}>
-              <EventStream items={events} loading={busy} />
+            <SectionCard title="Events" right={<span className="muted">digest by default</span>}>
+              <EventStream items={events} loading={loading || polling} />
             </SectionCard>
           </div>
         </div>
 
-        <SectionCard title="Sources" right={<span className="muted">freshness & health</span>}>
-          <SourcesTable sources={data?.meta?.sources} />
-        </SectionCard>
+        <details className="card" open={false}>
+          <summary className="cardHeader" style={{ cursor: 'pointer' }}>
+            <h2 className="cardTitle">Sources</h2>
+            <div className="cardRight muted">freshness & health</div>
+          </summary>
+          <div className="cardBody">
+            <SourcesTable sources={data?.meta?.sources} />
+          </div>
+        </details>
       </main>
     </div>
   )
@@ -188,9 +172,7 @@ export default function DashboardPage() {
 function SourcesTable({
   sources
 }: {
-  sources:
-    | Record<string, { health?: DashboardHealth; freshnessMs?: number; message?: string }>
-    | undefined
+  sources: Record<string, { health?: DashboardHealth; freshnessMs?: number; message?: string }> | undefined
 }) {
   const keys = Object.keys(sources || {})
   if (!keys.length) return <div className="empty">No source metadata.</div>
@@ -211,9 +193,7 @@ function SourcesTable({
             <td>{k}</td>
             <td>{sources?.[k]?.health || 'unknown'}</td>
             <td>
-              {typeof sources?.[k]?.freshnessMs === 'number'
-                ? `${Math.round((sources?.[k]?.freshnessMs || 0) / 1000)}s`
-                : '—'}
+              {typeof sources?.[k]?.freshnessMs === 'number' ? `${Math.round((sources?.[k]?.freshnessMs || 0) / 1000)}s` : '—'}
             </td>
             <td className="muted">{sources?.[k]?.message || '—'}</td>
           </tr>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -712,3 +712,161 @@ a:hover { text-decoration: underline; }
 .kvRow { display: flex; justify-content: space-between; gap: 10px; padding: 8px 10px; border-radius: var(--r-lg); border: 1px solid rgba(255,255,255,0.10); background: rgba(0,0,0,0.12); }
 .kvRow .k { color: var(--muted); font-size: 12px; }
 .kvRow .v { color: var(--text2); font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
+
+/* ---------- P5: Dashboard overview hero (control-center clarity) ---------- */
+
+.heroCard {
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  background:
+    radial-gradient(120% 140% at 10% 0%, rgba(56,189,248,0.10), transparent 60%),
+    radial-gradient(120% 140% at 90% 0%, rgba(255,90,61,0.10), transparent 60%),
+    rgba(255, 255, 255, 0.04);
+  box-shadow: var(--shadow-md);
+  padding: 14px 14px;
+}
+
+.heroTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.heroKicker { font-size: 12px; letter-spacing: 0.3px; color: var(--muted); }
+.heroTitle { font-size: 22px; font-weight: 860; letter-spacing: 0.2px; line-height: 1.1; margin-top: 4px; }
+.heroSub { margin-top: 6px; font-size: 12px; }
+
+.heroActions { display: flex; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
+
+.heroMeta {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(0,0,0,0.10);
+  color: var(--text2);
+  font-size: 12px;
+}
+
+:root[data-theme='light'] .pill {
+  border-color: rgba(15,23,42,0.14);
+  background: rgba(255,255,255,0.72);
+}
+
+.heroGrid {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: minmax(260px, 0.9fr) minmax(320px, 1.15fr) minmax(320px, 1.2fr);
+  gap: 12px;
+  align-items: start;
+}
+
+@media (max-width: 1100px) {
+  .heroTop { flex-direction: column; }
+  .heroActions { justify-content: flex-start; }
+  .heroGrid { grid-template-columns: 1fr; }
+}
+
+.heroPanel {
+  border: 1px solid rgba(255,255,255,0.10);
+  border-radius: var(--r-xl);
+  background: var(--glass);
+  overflow: hidden;
+}
+
+.heroPanelTitle {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.03);
+  font-weight: 780;
+  font-size: 12px;
+  color: var(--text);
+}
+
+.heroPanelBody { padding: 10px 12px; }
+
+.healthRow { display: flex; gap: 10px; align-items: center; }
+.healthHint { margin-top: 8px; font-size: 12px; line-height: 1.35; }
+
+/* Staff snapshot */
+.staff { display: flex; flex-direction: column; gap: 10px; }
+.staffCounts { display: flex; gap: 10px; flex-wrap: wrap; }
+
+.staffList { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px; }
+.staffRow { border-radius: var(--r-lg); border: 1px solid rgba(255,255,255,0.10); background: rgba(0,0,0,0.12); overflow: hidden; }
+.staffLink {
+  display: grid;
+  grid-template-columns: 28px minmax(120px, 1fr) minmax(160px, 1.2fr);
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  color: inherit;
+  text-decoration: none;
+}
+.staffLink:hover { border-color: rgba(255,255,255,0.20); box-shadow: 0 0 0 1px rgba(255,90,61,0.14); }
+.staffAvatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.04);
+}
+
+.staffMain { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; min-width: 0; }
+.staffName { font-weight: 820; }
+.staffRole { color: var(--muted); font-size: 12px; }
+.staffStatus { font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.12); background: rgba(0,0,0,0.10); }
+.staffStatus.tone-ok { border-color: rgba(38,209,139,0.50); color: rgba(38,209,139,0.95); }
+.staffStatus.tone-warn { border-color: rgba(255,176,32,0.55); color: rgba(255,176,32,0.98); }
+.staffStatus.tone-bad { border-color: rgba(255,61,129,0.55); color: rgba(255,61,129,0.98); }
+.staffStatus.tone-muted { opacity: 0.8; }
+
+.staffTask {
+  color: var(--text2);
+  font-size: 12px;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+  .staffLink { grid-template-columns: 28px 1fr; }
+  .staffTask { grid-column: 1 / -1; white-space: normal; }
+}
+
+.staffHint { font-size: 12px; }
+
+/* Actionable digest */
+.digestList { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px; }
+.digestItem { padding: 8px 10px; border-radius: var(--r-lg); border: 1px solid rgba(255,255,255,0.10); background: rgba(0,0,0,0.12); }
+.digestTop { display: flex; justify-content: space-between; gap: 10px; align-items: baseline; }
+.digestTitle { font-weight: 780; }
+.digestMsg { margin-top: 4px; color: var(--text2); font-size: 12px; line-height: 1.35; }
+.digestMeta { margin-top: 6px; display: inline-flex; gap: 8px; flex-wrap: wrap; }
+.digestHint { margin-top: 10px; font-size: 12px; }
+
+/* Event detail toggle */
+.eventDetailToggle { margin-top: 6px; }
+.eventDetailSummary {
+  cursor: pointer;
+  list-style: none;
+  color: var(--muted);
+  font-size: 11px;
+}
+.eventDetailSummary::-webkit-details-marker { display: none; }
+.eventDetailSummary:hover { text-decoration: underline; }


### PR DESCRIPTION
Closes #62\n\nWhat changed\n- Added an overview hero on Dashboard to answer: health/freshness, who is busy, what needs attention.\n- Staff snapshot panel (agent list + active/blocked/offline counts).\n- Actionable digest panel (warn/error-first) with URL linkify.\n- Events stream now shows digest by default; raw detail is behind an expand toggle.\n- Frontend dashboard normalizer now prefers backend-provided data.events / data.timeline when available, falling back to recentEvents.\n\nChecked\n- npm test (repo root)\n- web: npm run typecheck + npm run build\n\nNotes\n- No backend changes; strictly UI/normalization improvements.