### PR TITLE
[P5-ops] Headless viewport smoke via Playwright (CI-friendly)

### DIFF
--- a/.github/workflows/viewport-smoke.yml
+++ b/.github/workflows/viewport-smoke.yml
@@ -1,0 +1,88 @@
+name: viewport-smoke
+
+on:
+  workflow_dispatch:
+  push:
+    # Only auto-run on this ops branch to produce evidence once.
+    branches:
+      - claw/gouzi/p5-ops-*
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install backend deps
+        run: npm ci
+
+      - name: Install web deps
+        run: npm --prefix web ci
+
+      - name: Prepare minimal runtime fixture
+        run: |
+          mkdir -p .tmp/runtime
+          cat > .tmp/runtime/scores.json <<'JSON'
+          {
+            "ollie": {"name":"Ollie","emoji":"🦦","role":"manager","score":0,"updated_at":"2026-03-01 00:00:00Z","history":[]}
+          }
+          JSON
+          echo '[]' > .tmp/runtime/tasks.json
+          echo '[]' > .tmp/runtime/events.json
+
+      - name: Start backend
+        run: |
+          OPENCLAW_RUNTIME_DIR="$GITHUB_WORKSPACE/.tmp/runtime" PORT=3000 node src/server.js >backend.log 2>&1 &
+          echo $! > backend.pid
+
+      - name: Start web dev server
+        run: |
+          npm --prefix web run dev -- --host 127.0.0.1 --port 5173 >web.log 2>&1 &
+          echo $! > web.pid
+
+      - name: Wait for services
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:3000/health >/dev/null 2>&1 && curl -fsS http://127.0.0.1:5173/ >/dev/null 2>&1; then
+              echo "services ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "services not ready" >&2
+          echo "--- backend.log ---"; tail -n 200 backend.log || true
+          echo "--- web.log ---"; tail -n 200 web.log || true
+          exit 1
+
+      - name: Install Playwright (Chromium)
+        run: |
+          npm i playwright@1.50.1 --no-save
+          npx playwright install --with-deps chromium
+
+      - name: Run viewport smoke
+        run: |
+          node scripts/viewport_smoke.mjs --base-url http://127.0.0.1:5173 --out artifacts/viewport-smoke
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: viewport-smoke
+          path: |
+            artifacts/viewport-smoke/**
+            backend.log
+            web.log
+
+      - name: Cleanup
+        if: always()
+        run: |
+          if [ -f web.pid ]; then kill $(cat web.pid) || true; fi
+          if [ -f backend.pid ]; then kill $(cat backend.pid) || true; fi

--- a/docs/ops/viewport-smoke.md
+++ b/docs/ops/viewport-smoke.md
@@ -1,0 +1,36 @@
+# Viewport smoke (headless Playwright)
+
+目的：在**无桌面环境**下产出 1440/1024/375 三档截图，用于回归 overview/staff/markdown 等关键页面布局与滚动体验。
+
+## CI（推荐 / 可复现）
+
+仓库内提供 GitHub Actions workflow：`.github/workflows/viewport-smoke.yml`
+
+- 自动触发：本次 ops 分支 push（用于产出一次证据）
+- 常规使用：Actions 手动 `Run workflow`（`workflow_dispatch`）
+
+Workflow 会：
+
+1. 启动后端（3000）+ Vite dev server（5173）
+2. 安装 Playwright Chromium 及系统依赖（runner 有 sudo）
+3. 对以下路由生成截图并输出 `summary.json`：
+   - `/`、`/staff`、`/markdown`
+   - viewport：1440 / 1024 / 375
+
+产物：Actions artifact `viewport-smoke`（包含 screenshots + backend/web logs）。
+
+## 本机无 sudo 的情况
+
+当前 host 若缺 `libatk-1.0.so.0` 等系统库，直接运行 Playwright 的 `headless_shell` 会失败。
+
+可选方案：
+
+- 使用 GitHub Actions（上面已覆盖）
+- 或用 Playwright 官方容器镜像（需要本机可用 Docker）：
+
+```bash
+docker run --rm -t \
+  -v "$PWD:/work" -w /work \
+  mcr.microsoft.com/playwright:v1.50.1-jammy \
+  bash -lc 'npm ci && npm --prefix web ci && OPENCLAW_RUNTIME_DIR=/work/.tmp/runtime PORT=3000 node src/server.js & npm --prefix web run dev -- --host 127.0.0.1 --port 5173 & sleep 3 && node scripts/viewport_smoke.mjs --base-url http://127.0.0.1:5173 --out artifacts/viewport-smoke'
+```

--- a/scripts/viewport_smoke.mjs
+++ b/scripts/viewport_smoke.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = { baseUrl: process.env.BASE_URL || 'http://127.0.0.1:5173', outDir: 'artifacts/viewport-smoke' };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--base-url') args.baseUrl = argv[++i];
+    else if (token === '--out') args.outDir = argv[++i];
+    else if (token === '--help') args.help = true;
+  }
+  return args;
+}
+
+function slugifyRoute(route) {
+  if (route === '/' || route === '') return 'home';
+  return route.replace(/^\//, '').replace(/[^a-z0-9]+/gi, '-').replace(/-+/g, '-').replace(/^-|-$/g, '') || 'route';
+}
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function waitForOk(url, { timeoutMs = 60_000, intervalMs = 1_000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  // Node 22 has global fetch.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const res = await fetch(url, { redirect: 'follow' });
+      if (res.ok) return;
+    } catch {
+      // ignore
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Timeout waiting for OK: ${url}`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: node scripts/viewport_smoke.mjs [--base-url http://127.0.0.1:5173] [--out artifacts/viewport-smoke]');
+    process.exit(0);
+  }
+
+  // Lazy import so the script can be present without requiring playwright at install-time.
+  const { chromium } = await import('playwright');
+
+  const routes = ['/', '/staff', '/markdown'];
+  const viewports = [
+    { name: '1440', width: 1440, height: 900 },
+    { name: '1024', width: 1024, height: 768 },
+    { name: '375', width: 375, height: 812 },
+  ];
+
+  const runId = new Date().toISOString().replace(/[:.]/g, '-');
+  const outRoot = path.resolve(args.outDir, runId);
+  await ensureDir(outRoot);
+
+  // Best-effort readiness gate.
+  await waitForOk(`${args.baseUrl}/`);
+
+  const browser = await chromium.launch({ headless: true });
+
+  const results = [];
+  try {
+    for (const viewport of viewports) {
+      const context = await browser.newContext({ viewport: { width: viewport.width, height: viewport.height } });
+      const page = await context.newPage();
+
+      const consoleErrors = [];
+      const pageErrors = [];
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') consoleErrors.push({ text: msg.text() });
+      });
+      page.on('pageerror', (err) => {
+        pageErrors.push({ message: err?.message ?? String(err) });
+      });
+
+      for (const route of routes) {
+        const url = new URL(route, args.baseUrl).toString();
+        const routeSlug = slugifyRoute(route);
+        const screenshotPath = path.join(outRoot, `${routeSlug}.${viewport.name}.png`);
+
+        const startedAt = Date.now();
+        const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+        await page.waitForTimeout(1_000);
+
+        const navDurationMs = await page.evaluate(() => {
+          const entry = performance.getEntriesByType('navigation')[0];
+          if (entry && typeof entry.duration === 'number') return entry.duration;
+          return null;
+        });
+
+        await page.screenshot({ path: screenshotPath, fullPage: true });
+
+        results.push({
+          route,
+          url,
+          viewport,
+          status: response?.status() ?? null,
+          navDurationMs,
+          wallTimeMs: Date.now() - startedAt,
+          screenshotPath: path.relative(process.cwd(), screenshotPath),
+          consoleErrorCount: consoleErrors.length,
+          pageErrorCount: pageErrors.length,
+        });
+      }
+
+      await page.close();
+      await context.close();
+    }
+
+    const summary = {
+      baseUrl: args.baseUrl,
+      outDir: path.relative(process.cwd(), outRoot),
+      generatedAt: new Date().toISOString(),
+      routes,
+      viewports,
+      results,
+    };
+
+    await fs.writeFile(path.join(outRoot, 'summary.json'), JSON.stringify(summary, null, 2));
+
+    const hadErrors = results.some((r) => (r.status && r.status >= 400) || r.consoleErrorCount > 0 || r.pageErrorCount > 0);
+    console.log(JSON.stringify({ ok: !hadErrors, outDir: summary.outDir, resultCount: results.length }, null, 2));
+
+    if (hadErrors) process.exitCode = 2;
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Refs #64\n\n- Add headless Playwright script to generate screenshots at 1440/1024/375 for /, /staff, /markdown\n- Add GitHub Actions workflow to run it in ubuntu-latest (installs Chromium deps) and upload artifacts\n- Doc: docs/ops/viewport-smoke.md\n\nMotivation: host lacks system libs (e.g. libatk) and no sudo; CI runner can run reliably.